### PR TITLE
Fixing competition results table layout issues. Should fix #288

### DIFF
--- a/codalab/apps/web/static/css/codalab.css
+++ b/codalab/apps/web/static/css/codalab.css
@@ -7698,8 +7698,8 @@ body {
   }
 }
 /* line 31, ../sass/codalab.scss */
-[class*="column"] + [class*="column"]:last-child {
-  float: none;
+.column-selectable:last-child {
+  float: none !important;
 }
 
 /* Panels */

--- a/codalab/apps/web/static/sass/codalab.scss
+++ b/codalab/apps/web/static/sass/codalab.scss
@@ -27,9 +27,9 @@ body { font-size: $base-font-size; overflow: auto; }  // added overflow: auto
   }
 
 
-// _grid customizations
-[class*="column"] + [class*="column"]:last-child {
-    float: none; // changed from right
+// leaderboard customization
+.column-selectable:last-child {
+    float: none !important;
 }
 
 


### PR DESCRIPTION
Hope this fixes it without creating new issues elsewhere. I've commented the codalab.css file so that it can easily be undone.
