### PR TITLE
Remove protocol from URLs for items on the CDN in order to support https.

### DIFF
--- a/codalab/apps/web/templates/base.html
+++ b/codalab/apps/web/templates/base.html
@@ -43,8 +43,8 @@
     {% analytical_head_top %}
     {% analytical_head_bottom %}
 
-    <script src="http://ajax.aspnetcdn.com/ajax/jquery/jquery-1.10.2.min.js"></script>
-    <script src="http://ajax.aspnetcdn.com/ajax/jquery.ui/1.10.1/jquery-ui.min.js"></script>
+    <script src="//ajax.aspnetcdn.com/ajax/jquery/jquery-1.10.2.min.js"></script>
+    <script src="//ajax.aspnetcdn.com/ajax/jquery.ui/1.10.1/jquery-ui.min.js"></script>
     <script src="{{ STATIC_URL }}js/vendor/jquery.scrollTo.min.js"></script>
 
     <!-- From Charles Sterling for Analytics -->
@@ -169,8 +169,8 @@
     </footer>
 
     <!-- Check for Zepto support, load jQuery if necessary -->
-    <script src="http://ajax.aspnetcdn.com/ajax/jquery.validate/1.11.1/jquery.validate.min.js"></script>
-    <script src="http://ajax.aspnetcdn.com/ajax/jquery.dataTables/1.9.4/jquery.dataTables.min.js"></script>
+    <script src="//ajax.aspnetcdn.com/ajax/jquery.validate/1.11.1/jquery.validate.min.js"></script>
+    <script src="//ajax.aspnetcdn.com/ajax/jquery.dataTables/1.9.4/jquery.dataTables.min.js"></script>
     <script src="{{ STATIC_URL }}js/vendor/jquery.liteuploader-1.4.1.min.js"></script>
 
     <!-- Included JS Files (Compressed) -->


### PR DESCRIPTION
Remove protocol from URLs for items on the CDN in order to support secure http.
