### PR TITLE
Add ability for competition organizers to hide results in a phase per #315

### DIFF
--- a/codalab/apps/api/routers.py
+++ b/codalab/apps/api/routers.py
@@ -21,9 +21,7 @@ urlpatterns += (
     url(r'^competition/(?P<pk>\d+)/phases/(?P<phasenumber>\d+)$',views.competitionphase_retrieve,name='api_competitionphase'),
     url(r'^competition/(?P<competition_id>\d+)/phases/(?P<phase_id>\d+)/leaderboard$',views.leaderboard_retrieve, name='api_phase_leaderboard'),
     url(r'^competition/(?P<pk>\d+)/phases/$',views.competitionphase_list,name='api_competitionphases_list'),
-    url(r'^competition/(?P<competition_id>\d+)/submissions/(?P<phase_id>\d+)$',views.competition_scores_list,name='api_competition_scores'),
-    url(r'^competition/(?P<competition_id>\d+)/submissions/(?P<phase_id>\d+)/(?P<participant_id>\d+)$',views.competition_scores_list,name='api_competition_participant_scores'),
-    
+
     url(r'^competition/(?P<competition_id>\d+)/pages/(?P<category>[a-zA-Z][\w\d\-\_]*)/$', views.competition_page_list, name='api_competition_page_list'),
     url(r'^competition/(?P<competition_id>\d+)/pages/(?P<pk>\d+)$', views.competition_page, name='api_competition_page'),
     url(r'^competition/(?P<competition_id>\d+)/pages/$', views.competition_page_list, name='api_competition_page_list'),

--- a/codalab/apps/api/serializers.py
+++ b/codalab/apps/api/serializers.py
@@ -46,9 +46,10 @@ class CompetitionParticipantSerial(serializers.ModelSerializer):
 
 class CompetitionSubmissionSerial(serializers.ModelSerializer):
     status = serializers.SlugField(source="status.codename", read_only=True)
+    filename = serializers.Field(source="get_filename")
     class Meta:
         model = webmodels.CompetitionSubmission
-        fields = ('id','status','status_details','submitted_at','submission_number', 'file')
+        fields = ('id','status','status_details','submitted_at','submission_number', 'file', 'filename')
         read_only_fields = ('participant', 'phase', 'id','status_details','submitted_at','submission_number')
 
 class PhaseSerial(serializers.ModelSerializer):

--- a/codalab/apps/api/views.py
+++ b/codalab/apps/api/views.py
@@ -48,7 +48,7 @@ class CompetitionCreationApi(views.APIView):
         logger.debug("CompetitionCreation def: owner=%s; def=%s; blob=%s.", owner.id, cdb.pk, cdb.config_bundle.name)
         job = create_competition(cdb.pk)
         logger.debug("CompetitionCreation job: owner=%s; def=%s; job=%s.", owner.id, cdb.pk, job.pk)
-        return Response({'token' : job.pk }, status=status.HTTP_201_CREATED)
+        return Response({'token' : job.pk}, status=status.HTTP_201_CREATED)
 
 @permission_classes((permissions.IsAuthenticated,))
 class CompetitionCreationStatusApi(views.APIView):
@@ -68,7 +68,7 @@ class CompetitionCreationStatusApi(views.APIView):
         except Job.DoesNotExist:
             return Response(status=status.HTTP_404_NOT_FOUND)
         logger.debug("CompetitionCreationStatus: requestor=%s; job=%s; job.status:%s.", user_id, job.pk, job.status)
-        data = {'status' : job.get_status_code_name() }
+        data = {'status' : job.get_status_code_name()}
         info = job.get_task_info()
         if 'competition_id' in info:
             data['id'] = info['competition_id']
@@ -99,7 +99,7 @@ class CompetitionAPIViewSet(viewsets.ModelViewSet):
 
         return Response(json.dumps(response), content_type="application/json")
 
-    @action(methods=['GET'],permission_classes=[permissions.IsAuthenticated])
+    @action(methods=['GET'], permission_classes=[permissions.IsAuthenticated])
     def publish(self, request, pk):
         """
         Publish a competition.
@@ -142,9 +142,9 @@ class CompetitionAPIViewSet(viewsets.ModelViewSet):
         else:
             status = webmodels.ParticipantStatus.objects.get(codename=webmodels.ParticipantStatus.APPROVED)
 
-        p,cr = webmodels.CompetitionParticipant.objects.get_or_create(user=self.request.user,
-                                                                      competition=comp,
-                                                                      defaults={'status': status, 'reason': None})
+        p, cr = webmodels.CompetitionParticipant.objects.get_or_create(user=self.request.user,
+                                                                       competition=comp,
+                                                                       defaults={'status': status, 'reason': None})
 
         response_data = {
             'result' : 201 if cr else 200,
@@ -153,24 +153,24 @@ class CompetitionAPIViewSet(viewsets.ModelViewSet):
 
         return Response(json.dumps(response_data), content_type="application/json")
 
-    def _get_userstatus(self,request,pk=None,participant_id=None):
+    def _get_userstatus(self, request, pk=None, participant_id=None):
         comp = self.get_object()
         resp = {}
         status = 200
         try:
-            p = webmodels.CompetitionParticipant.objects.get(user=self.request.user,competition=comp)
+            p = webmodels.CompetitionParticipant.objects.get(user=self.request.user, competition=comp)
             resp = {'status': p.status.codename, 'reason': p.reason}
         except ObjectDoesNotExist:
             resp = {'status': None, 'reason': None}
             status = 400
-        return Response(resp,status=status)
+        return Response(resp, status=status)
 
     @link(permission_classes=[permissions.IsAuthenticated])
-    def mystatus(self,request,pk=None):
-        return self._get_userstatus(request,pk)
+    def mystatus(self, request, pk=None):
+        return self._get_userstatus(request, pk)
 
-    @action(methods=['POST','PUT'], permission_classes=[permissions.IsAuthenticated])
-    def participation_status(self,request,pk=None):
+    @action(methods=['POST', 'PUT'], permission_classes=[permissions.IsAuthenticated])
+    def participation_status(self, request, pk=None):
         comp = self.get_object()
         resp = {}
         status = request.DATA['status']
@@ -195,26 +195,26 @@ class CompetitionAPIViewSet(viewsets.ModelViewSet):
         return Response(json.dumps(resp), content_type="application/json")
 
     @action(permission_classes=[permissions.IsAuthenticated])
-    def info(self,request,*args,**kwargs):
+    def info(self, request, *args, **kwargs):
         comp = self.get_object()
         comp.title = request.DATA.get('title')
         comp.description = request.DATA.get('description')
         comp.save()
-        return Response({ "data": {
-                              "title": comp.title,
-                              "description": comp.description,
-                              "imageUrl": comp.image.url if comp.image else None },
-                          "published": 3 }, status=200)
+        return Response({"data": {
+                             "title": comp.title,
+                             "description": comp.description,
+                             "imageUrl": comp.image.url if comp.image else None},
+                         "published": 3}, status=200)
 
-competition_list =   CompetitionAPIViewSet.as_view({'get':'list','post':'create', 'post': 'participate',})
-competition_retrieve =   CompetitionAPIViewSet.as_view({'get':'retrieve','put':'update', 'patch': 'partial_update'})
+competition_list = CompetitionAPIViewSet.as_view({'get':'list', 'post': 'participate'})
+competition_retrieve = CompetitionAPIViewSet.as_view({'get':'retrieve', 'put':'update', 'patch': 'partial_update'})
 
 class CompetitionParticipantAPIViewSet(viewsets.ModelViewSet):
     serializer_class = serializers.CompetitionParticipantSerial
     queryset = webmodels.CompetitionParticipant.objects.all()
 
     def get_queryset(self):
-        competition_id = self.kwargs.get('competition_id',None)
+        competition_id = self.kwargs.get('competition_id', None)
         return self.queryset.filter(competition__pk=competition_id)
 
 class CompetitionPhaseAPIViewset(viewsets.ModelViewSet):
@@ -222,8 +222,8 @@ class CompetitionPhaseAPIViewset(viewsets.ModelViewSet):
     queryset = webmodels.Competition.objects.all()
 
     def get_queryset(self):
-        competition_id = self.kwargs.get('pk',None)
-        phasenumber = self.kwargs.get('phasenumber',None)
+        competition_id = self.kwargs.get('pk', None)
+        phasenumber = self.kwargs.get('phasenumber', None)
         kw = {}
         if competition_id:
             kw['pk'] = competition_id
@@ -231,7 +231,7 @@ class CompetitionPhaseAPIViewset(viewsets.ModelViewSet):
             kw['phases__phasenumber'] = phasenumber
         return self.queryset.filter(**kw)
 
-competitionphase_list = CompetitionPhaseAPIViewset.as_view({'get':'list','post':'create'})
+competitionphase_list = CompetitionPhaseAPIViewset.as_view({'get':'list', 'post':'create'})
 competitionphase_retrieve = CompetitionPhaseAPIViewset.as_view({'get':'retrieve',
                                                                 'put':'update',
                                                                 'patch':'partial_update'})
@@ -257,11 +257,11 @@ class CompetitionPageViewSet(viewsets.ModelViewSet):
         else:
             return self.queryset
 
-    def dispatch(self,request,*args,**kwargs):
+    def dispatch(self, request, *args, **kwargs):
         if 'competition_id' in kwargs:
             self._pagecontainer_q = webmodels.PageContainer.objects.filter(object_id=kwargs['competition_id'],
                                                                            content_type=self.content_type)
-        return super(CompetitionPageViewSet,self).dispatch(request,*args,**kwargs)
+        return super(CompetitionPageViewSet, self).dispatch(request, *args, **kwargs)
 
     @property
     def pagecontainer(self):
@@ -272,9 +272,9 @@ class CompetitionPageViewSet(viewsets.ModelViewSet):
                 self._pagecontainer = None
         return self._pagecontainer
 
-    def new_pagecontainer(self,competition_id):
+    def new_pagecontainer(self, competition_id):
         try:
-            competition=webmodels.Competition.objects.get(pk=competition_id)
+            competition = webmodels.Competition.objects.get(pk=competition_id)
         except ObjectDoesNotExist:
             raise Http404
         self._pagecontainer = webmodels.PageContainer.objects.create(object_id=competition_id,
@@ -282,19 +282,19 @@ class CompetitionPageViewSet(viewsets.ModelViewSet):
         return self._pagecontainer
 
     def get_serializer_context(self):
-        ctx = super(CompetitionPageViewSet,self).get_serializer_context()
+        ctx = super(CompetitionPageViewSet, self).get_serializer_context()
         if 'competition_id' in self.kwargs:
             ctx.update({'container': self.pagecontainer})
         return ctx
 
-    def create(self,request,*args,**kwargs):
+    def create(self, request, *args, **kwargs):
         container = self.pagecontainer
         if not container:
             container = self.new_pagecontainer(self.kwargs.get('competition_id'))
-        return  super(CompetitionPageViewSet,self).create(request,*args,**kwargs)
+        return  super(CompetitionPageViewSet, self).create(request, *args, **kwargs)
 
-competition_page_list = CompetitionPageViewSet.as_view({'get':'list','post':'create'})
-competition_page = CompetitionPageViewSet.as_view({'get':'retrieve','put':'update','patch':'partial_update'})
+competition_page_list = CompetitionPageViewSet.as_view({'get':'list', 'post':'create'})
+competition_page = CompetitionPageViewSet.as_view({'get':'retrieve', 'put':'update', 'patch':'partial_update'})
 
 
 @permission_classes((permissions.IsAuthenticated,))
@@ -306,7 +306,7 @@ class CompetitionSubmissionViewSet(viewsets.ModelViewSet):
     def get_queryset(self):
         return self.queryset.filter(phase__competition__pk=self.kwargs['competition_id'])
 
-    def pre_save(self,obj):
+    def pre_save(self, obj):
         try:
             obj.participant = webmodels.CompetitionParticipant.objects.filter(
                                 competition=self.kwargs['competition_id'], user=self.request.user).get()
@@ -318,16 +318,16 @@ class CompetitionSubmissionViewSet(viewsets.ModelViewSet):
             if phase.is_active is True:
                 break
         if phase is None or phase.is_active is False:
-            raise PermissionDenied(detail = 'Competition phase is closed.')
+            raise PermissionDenied(detail='Competition phase is closed.')
         obj.phase = phase
 
-    def post_save(self,obj,created):
+    def post_save(self, obj, created):
         if created:
             evaluate_submission(obj.pk, obj.phase.is_scoring_only)
 
     def handle_exception(self, exc):
         if type(exc) is DjangoPermissionDenied:
-            exc = PermissionDenied(detail = str(exc))
+            exc = PermissionDenied(detail=str(exc))
         return super(CompetitionSubmissionViewSet, self).handle_exception(exc)
 
     @action(methods=["DELETE"])
@@ -340,10 +340,12 @@ class CompetitionSubmissionViewSet(viewsets.ModelViewSet):
         if not participant.is_approved:
             raise PermissionDenied()
         submission = webmodels.CompetitionSubmission.objects.get(id=pk)
-        if submission.phase.is_active is False:
-            raise PermissionDenied(detail = 'Competition phase is closed.')
+        if not submission.phase.is_active:
+            raise PermissionDenied(detail='Competition phase is closed.')
+        if submission.phase.is_blind:
+            raise PermissionDenied(detail='Competition phase does not allow participants to modify the leaderboard.')
         if submission.participant.user != self.request.user:
-            raise ParseError(detail = 'Invalid submission')
+            raise ParseError(detail='Invalid submission')
         response = dict()
         lb = webmodels.PhaseLeaderBoard.objects.get(phase=submission.phase)
         lbe = webmodels.PhaseLeaderBoardEntry.objects.get(board=lb, result=submission)
@@ -361,18 +363,14 @@ class CompetitionSubmissionViewSet(viewsets.ModelViewSet):
         if not participant.is_approved:
             raise PermissionDenied()
         submission = webmodels.CompetitionSubmission.objects.get(id=pk)
-        if submission.phase.is_active is False:
-            raise PermissionDenied(detail = 'Competition phase is closed.')
+        if not submission.phase.is_active:
+            raise PermissionDenied(detail='Competition phase is closed.')
+        if submission.phase.is_blind:
+            raise PermissionDenied(detail='Competition phase does not allow participants to modify the leaderboard.')
         if submission.participant.user != self.request.user:
-            raise ParseError(detail = 'Invalid submission')
+            raise ParseError(detail='Invalid submission')
         response = dict()
-        lb,_ = webmodels.PhaseLeaderBoard.objects.get_or_create(phase=submission.phase)
-        # Currently we only allow one submission into the leaderboard although the leaderboard
-        # is setup to accept multiple submissions from the same participant.
-        entries = webmodels.PhaseLeaderBoardEntry.objects.filter(board=lb, result__participant=participant)
-        for entry in entries:
-            entry.delete()
-        lbe,cr = webmodels.PhaseLeaderBoardEntry.objects.get_or_create(board=lb, result=submission)
+        _, cr = webmodels.add_submission_to_leaderboard(submission)
         response['status'] = (201 if cr else 200)
         return Response(response, status=response['status'], content_type="application/json")
 
@@ -395,28 +393,10 @@ class LeaderBoardViewSet(viewsets.ModelViewSet):
             kw['phase__competition__pk'] = competition_id
         return self.queryset.filter(**kw)
 
-leaderboard_list = LeaderBoardViewSet.as_view({'get':'list','post':'create'} )
-leaderboard_retrieve = LeaderBoardViewSet.as_view( {'get':'retrieve','put':'update','patch':'partial_update'} )
+leaderboard_list = LeaderBoardViewSet.as_view({'get':'list', 'post':'create'})
+leaderboard_retrieve = LeaderBoardViewSet.as_view({'get':'retrieve', 'put':'update', 'patch':'partial_update'})
 
 class DefaultContentViewSet(viewsets.ModelViewSet):
     queryset = webmodels.DefaultContentItem.objects.all()
     serializer_class = serializers.DefaultContentSerial
 
-class SubmissionScoreViewSet(viewsets.ModelViewSet):
-    queryset = webmodels.CompetitionSubmission.objects.all()
-    serializer_class = serializers.CompetitionScoresSerial
-
-    def get_queryset(self):
-        kw = {}
-        competition_id = self.kwargs.get('competition_id', None)
-        phase_id = self.kwargs.get('phase_id', None)
-        participant_id = self.kwargs.get('participant_id', None)
-        if competition_id:
-            kw['submission__phase__competition__pk'] = competition_id
-        if phase_id:
-            kw['submission__phase__pk'] = phase_id
-        if participant_id:
-            kw['submission__participant__pk'] = participant_id
-        return self.queryset.filter(**kw)
-
-competition_scores_list = SubmissionScoreViewSet.as_view( {'get':'list'} )

--- a/codalab/apps/web/migrations/0006_auto__add_field_competitionsubmission_description__add_field_competiti.py
+++ b/codalab/apps/web/migrations/0006_auto__add_field_competitionsubmission_description__add_field_competiti.py
@@ -1,0 +1,307 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'CompetitionSubmission.description'
+        db.add_column(u'web_competitionsubmission', 'description',
+                      self.gf('django.db.models.fields.CharField')(default='', max_length=256, blank=True),
+                      keep_default=False)
+
+        # Adding field 'CompetitionPhase.leaderboard_management_mode'
+        db.add_column(u'web_competitionphase', 'leaderboard_management_mode',
+                      self.gf('django.db.models.fields.CharField')(default='default', max_length=50),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'CompetitionSubmission.description'
+        db.delete_column(u'web_competitionsubmission', 'description')
+
+        # Deleting field 'CompetitionPhase.leaderboard_management_mode'
+        db.delete_column(u'web_competitionphase', 'leaderboard_management_mode')
+
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'authenz.cluser': {
+            'Meta': {'object_name': 'ClUser'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'web.competition': {
+            'Meta': {'ordering': "['end_date']", 'object_name': 'Competition'},
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'competitioninfo_creator'", 'to': u"orm['authenz.ClUser']"}),
+            'description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'end_date': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'has_registration': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'image': ('django.db.models.fields.files.FileField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'image_url_base': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'last_modified': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'modified_by': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'competitioninfo_modified_by'", 'to': u"orm['authenz.ClUser']"}),
+            'published': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'web.competitiondefbundle': {
+            'Meta': {'object_name': 'CompetitionDefBundle'},
+            'config_bundle': ('django.db.models.fields.files.FileField', [], {'max_length': '100'}),
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'owner'", 'to': u"orm['authenz.ClUser']"})
+        },
+        u'web.competitionparticipant': {
+            'Meta': {'unique_together': "(('user', 'competition'),)", 'object_name': 'CompetitionParticipant'},
+            'competition': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'participants'", 'to': u"orm['web.Competition']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'reason': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'status': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['web.ParticipantStatus']"}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'participation'", 'to': u"orm['authenz.ClUser']"})
+        },
+        u'web.competitionphase': {
+            'Meta': {'ordering': "['phasenumber']", 'object_name': 'CompetitionPhase'},
+            'competition': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'phases'", 'to': u"orm['web.Competition']"}),
+            'datasets': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "'phase'", 'blank': 'True', 'to': u"orm['web.Dataset']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'input_data': ('django.db.models.fields.files.FileField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'is_scoring_only': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'label': ('django.db.models.fields.CharField', [], {'max_length': '50', 'blank': 'True'}),
+            'leaderboard_management_mode': ('django.db.models.fields.CharField', [], {'default': "'default'", 'max_length': '50'}),
+            'max_submissions': ('django.db.models.fields.PositiveIntegerField', [], {'default': '100'}),
+            'phasenumber': ('django.db.models.fields.PositiveIntegerField', [], {}),
+            'reference_data': ('django.db.models.fields.files.FileField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'scoring_program': ('django.db.models.fields.files.FileField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'start_date': ('django.db.models.fields.DateTimeField', [], {})
+        },
+        u'web.competitionsubmission': {
+            'Meta': {'unique_together': "(('submission_number', 'phase', 'participant'),)", 'object_name': 'CompetitionSubmission'},
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '256', 'blank': 'True'}),
+            'execution_key': ('django.db.models.fields.TextField', [], {'default': "''", 'blank': 'True'}),
+            'file': ('django.db.models.fields.files.FileField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'file_url_base': ('django.db.models.fields.CharField', [], {'max_length': '2000', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'inputfile': ('django.db.models.fields.files.FileField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'output_file': ('django.db.models.fields.files.FileField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'participant': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'submissions'", 'to': u"orm['web.CompetitionParticipant']"}),
+            'phase': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'submissions'", 'to': u"orm['web.CompetitionPhase']"}),
+            'prediction_output_file': ('django.db.models.fields.files.FileField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'prediction_runfile': ('django.db.models.fields.files.FileField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'runfile': ('django.db.models.fields.files.FileField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'status': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['web.CompetitionSubmissionStatus']"}),
+            'status_details': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'stderr_file': ('django.db.models.fields.files.FileField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'stdout_file': ('django.db.models.fields.files.FileField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'submission_number': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'submitted_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'})
+        },
+        u'web.competitionsubmissionstatus': {
+            'Meta': {'object_name': 'CompetitionSubmissionStatus'},
+            'codename': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '20'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '20'})
+        },
+        u'web.contentcategory': {
+            'Meta': {'object_name': 'ContentCategory'},
+            'codename': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '100'}),
+            'content_limit': ('django.db.models.fields.PositiveIntegerField', [], {'default': '1'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_menu': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'level': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'lft': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'parent': ('mptt.fields.TreeForeignKey', [], {'blank': 'True', 'related_name': "'children'", 'null': 'True', 'to': u"orm['web.ContentCategory']"}),
+            'rght': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'tree_id': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'visibility': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['web.ContentVisibility']"})
+        },
+        u'web.contentvisibility': {
+            'Meta': {'object_name': 'ContentVisibility'},
+            'classname': ('django.db.models.fields.CharField', [], {'max_length': '30', 'null': 'True', 'blank': 'True'}),
+            'codename': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '20'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '20'})
+        },
+        u'web.dataset': {
+            'Meta': {'ordering': "['number']", 'object_name': 'Dataset'},
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'datasets'", 'to': u"orm['authenz.ClUser']"}),
+            'datafile': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['web.ExternalFile']"}),
+            'description': ('django.db.models.fields.TextField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'number': ('django.db.models.fields.PositiveIntegerField', [], {'default': '1'})
+        },
+        u'web.defaultcontentitem': {
+            'Meta': {'object_name': 'DefaultContentItem'},
+            'category': ('mptt.fields.TreeForeignKey', [], {'to': u"orm['web.ContentCategory']"}),
+            'codename': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'initial_visibility': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['web.ContentVisibility']"}),
+            'label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'rank': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'required': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        },
+        u'web.externalfile': {
+            'Meta': {'object_name': 'ExternalFile'},
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['authenz.ClUser']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'source_address_info': ('django.db.models.fields.CharField', [], {'max_length': '200', 'blank': 'True'}),
+            'source_url': ('django.db.models.fields.URLField', [], {'max_length': '200'}),
+            'type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['web.ExternalFileType']"})
+        },
+        u'web.externalfilesource': {
+            'Meta': {'object_name': 'ExternalFileSource'},
+            'codename': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '50'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'service_url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'})
+        },
+        u'web.externalfiletype': {
+            'Meta': {'object_name': 'ExternalFileType'},
+            'codename': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '20'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '20'})
+        },
+        u'web.page': {
+            'Meta': {'ordering': "['rank']", 'unique_together': "(('label', 'category', 'container'),)", 'object_name': 'Page'},
+            'category': ('mptt.fields.TreeForeignKey', [], {'to': u"orm['web.ContentCategory']"}),
+            'codename': ('django.db.models.fields.SlugField', [], {'max_length': '100'}),
+            'container': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'pages'", 'to': u"orm['web.PageContainer']"}),
+            'defaults': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['web.DefaultContentItem']", 'null': 'True', 'blank': 'True'}),
+            'html': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'markup': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'rank': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'visibility': ('django.db.models.fields.BooleanField', [], {'default': 'True'})
+        },
+        u'web.pagecontainer': {
+            'Meta': {'unique_together': "(('object_id', 'content_type'),)", 'object_name': 'PageContainer'},
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200', 'blank': 'True'}),
+            'object_id': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'})
+        },
+        u'web.participantstatus': {
+            'Meta': {'object_name': 'ParticipantStatus'},
+            'codename': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'}),
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '30'})
+        },
+        u'web.phaseleaderboard': {
+            'Meta': {'object_name': 'PhaseLeaderBoard'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'phase': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'board'", 'unique': 'True', 'to': u"orm['web.CompetitionPhase']"})
+        },
+        u'web.phaseleaderboardentry': {
+            'Meta': {'unique_together': "(('board', 'result'),)", 'object_name': 'PhaseLeaderBoardEntry'},
+            'board': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'entries'", 'to': u"orm['web.PhaseLeaderBoard']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'result': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'leaderboard_entry_result'", 'to': u"orm['web.CompetitionSubmission']"})
+        },
+        u'web.submissioncomputedscore': {
+            'Meta': {'object_name': 'SubmissionComputedScore'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'operation': ('django.db.models.fields.CharField', [], {'max_length': '10'}),
+            'scoredef': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'computed_score'", 'unique': 'True', 'to': u"orm['web.SubmissionScoreDef']"})
+        },
+        u'web.submissioncomputedscorefield': {
+            'Meta': {'object_name': 'SubmissionComputedScoreField'},
+            'computed': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'fields'", 'to': u"orm['web.SubmissionComputedScore']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'scoredef': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['web.SubmissionScoreDef']"})
+        },
+        u'web.submissionresultgroup': {
+            'Meta': {'ordering': "['ordering']", 'object_name': 'SubmissionResultGroup'},
+            'competition': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['web.Competition']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'label': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'ordering': ('django.db.models.fields.PositiveIntegerField', [], {'default': '1'}),
+            'phases': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['web.CompetitionPhase']", 'through': u"orm['web.SubmissionResultGroupPhase']", 'symmetrical': 'False'})
+        },
+        u'web.submissionresultgroupphase': {
+            'Meta': {'unique_together': "(('group', 'phase'),)", 'object_name': 'SubmissionResultGroupPhase'},
+            'group': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['web.SubmissionResultGroup']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'phase': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['web.CompetitionPhase']"})
+        },
+        u'web.submissionscore': {
+            'Meta': {'unique_together': "(('result', 'scoredef'),)", 'object_name': 'SubmissionScore'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'result': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'scores'", 'to': u"orm['web.CompetitionSubmission']"}),
+            'scoredef': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['web.SubmissionScoreDef']"}),
+            'value': ('django.db.models.fields.DecimalField', [], {'max_digits': '20', 'decimal_places': '10'})
+        },
+        u'web.submissionscoredef': {
+            'Meta': {'unique_together': "(('key', 'competition'),)", 'object_name': 'SubmissionScoreDef'},
+            'competition': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['web.Competition']"}),
+            'computed': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['web.SubmissionResultGroup']", 'through': u"orm['web.SubmissionScoreDefGroup']", 'symmetrical': 'False'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.SlugField', [], {'max_length': '50'}),
+            'label': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'numeric_format': ('django.db.models.fields.CharField', [], {'max_length': '20', 'null': 'True', 'blank': 'True'}),
+            'selection_default': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'show_rank': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'sorting': ('django.db.models.fields.SlugField', [], {'default': "'asc'", 'max_length': '20'})
+        },
+        u'web.submissionscoredefgroup': {
+            'Meta': {'unique_together': "(('scoredef', 'group'),)", 'object_name': 'SubmissionScoreDefGroup'},
+            'group': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['web.SubmissionResultGroup']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'scoredef': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['web.SubmissionScoreDef']"})
+        },
+        u'web.submissionscoreset': {
+            'Meta': {'unique_together': "(('key', 'competition'),)", 'object_name': 'SubmissionScoreSet'},
+            'competition': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['web.Competition']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'label': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'level': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'lft': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'parent': ('mptt.fields.TreeForeignKey', [], {'blank': 'True', 'related_name': "'children'", 'null': 'True', 'to': u"orm['web.SubmissionScoreSet']"}),
+            'rght': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'scoredef': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['web.SubmissionScoreDef']", 'null': 'True', 'blank': 'True'}),
+            'tree_id': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'})
+        }
+    }
+
+    complete_apps = ['web']

--- a/codalab/apps/web/models.py
+++ b/codalab/apps/web/models.py
@@ -3,7 +3,7 @@ import logging
 import random
 import operator
 import os, io
-from os.path import abspath, basename, dirname, join, normpath
+from os.path import abspath, basename, dirname, join, normpath, split
 import zipfile
 import yaml
 import tempfile
@@ -285,6 +285,32 @@ def submission_prediction_runfile_name(instance, filename="run.txt"):
 def submission_prediction_output_filename(instance, filename="output.zip"):
     return os.path.join(submission_root(instance), "pred", "run", filename)
 
+class _LeaderboardManagementMode(object):
+    """
+    Provides a set of constants which define when results become visible to participants
+    and how successful submisstion are added to the leaderboard.
+    """
+    @property
+    def DEFAULT(self):
+        """
+        Specifies that results are visible as soon as they are available and that adding
+        a successful submission to the leaderboard is a manual step.
+        """
+        return 'default'
+    @property
+    def HIDE_RESULTS(self):
+        """
+        Specifies that results are hidden from participants until competition owners make
+        them visible and that a participant's last successful submission is automatically
+        added to the leaderboard.
+        """
+        return 'hide_results'
+    def is_valid(self, mode):
+        """Returns true if the given string is a valid constant to define a management mode."""
+        return mode == self.DEFAULT or mode == self.HIDE_RESULTS
+
+LeaderboardManagementMode = _LeaderboardManagementMode()
+
 # Competition Phase
 class CompetitionPhase(models.Model):
     """
@@ -300,6 +326,7 @@ class CompetitionPhase(models.Model):
     reference_data = models.FileField(upload_to=phase_reference_data_file, storage=BundleStorage,null=True,blank=True)
     input_data = models.FileField(upload_to=phase_input_data_file, storage=BundleStorage,null=True,blank=True)
     datasets = models.ManyToManyField(Dataset, blank=True, related_name='phase')
+    leaderboard_management_mode = models.CharField(max_length=50, default=LeaderboardManagementMode.DEFAULT)
 
     class Meta:
         ordering = ['phasenumber']
@@ -329,6 +356,13 @@ class CompetitionPhase(models.Model):
     def is_past(self):
         """ Returns true if this phase of the competition has already ended. """
         return (not self.is_active) and (not self.is_future)
+
+    @property
+    def is_blind(self):
+        """
+        Indicates whether results are always hidden from participants.
+        """
+        return self.leaderboard_management_mode == LeaderboardManagementMode.HIDE_RESULTS
 
     @staticmethod
     def rank_values(ids, id_value_pairs, sort_ascending=True, eps=1.0e-12):
@@ -554,10 +588,14 @@ class CompetitionSubmissionStatus(models.Model):
 
 # Competition Submission
 class CompetitionSubmission(models.Model):
+    """
+    Represents a submission from a competition participant.
+    """
     participant = models.ForeignKey(CompetitionParticipant, related_name='submissions')
     phase = models.ForeignKey(CompetitionPhase, related_name='submissions')
     file = models.FileField(upload_to=submission_file_name, storage=BundleStorage, null=True, blank=True)
     file_url_base = models.CharField(max_length=2000, blank=True)
+    description = models.CharField(max_length=256, blank=True)
     inputfile = models.FileField(upload_to=submission_inputfile_name, storage=BundleStorage, null=True, blank=True)
     runfile = models.FileField(upload_to=submission_runfile_name, storage=BundleStorage, null=True, blank=True)
     submitted_at = models.DateTimeField(auto_now_add=True)
@@ -608,6 +646,53 @@ class CompetitionSubmission(models.Model):
         print "Calling super save."
         res = super(CompetitionSubmission,self).save(*args,**kwargs)
         return res
+
+    def get_filename(self):
+        """
+        Returns the short name of the file which was uploaded to create the submission.
+        """
+        return split(self.file.name)[1]
+
+    def get_file_for_download(self, key, requested_by, requested_by_competition_owner=False):
+        """
+        Returns the FileField object for the file that is to be downloaded by the given user.
+
+        key: A name identifying the file to download. The choices are 'input.zip', 'output.zip',
+           'prediction-output.zip', 'stdout.txt' or 'stderr.txt'.
+        requested_by: A user object identifying the user making the request to access the file.
+        requested_by_competition_owner: A boolean flag indicating whether the user is making
+           the request as a competition owner (True) or as a competition participant (False).
+           Access rules are affected by the value of this flag.
+
+        Raises:
+           ValueError exception for improper arguments.
+           PermissionDenied exception when access to the file cannot be granted.
+        """
+        downloadable_files = {
+            'input.zip': ('file', 'zip', False),
+            'output.zip': ('output_file', 'zip', True),
+            'prediction-output.zip': ('prediction_output_file', 'zip', True),
+            'stdout.txt': ('stdout_file', 'txt', True),
+            'stderr.txt': ('stderr_file', 'txt', False)
+        }
+        if key not in downloadable_files:
+            raise ValueError("File requested is not valid.")
+        file_attr, file_ext, file_has_restricted_access = downloadable_files[key]
+        # Verify access rules
+        if requested_by_competition_owner:
+            # User making request must be in the "competition owner" group.
+            if self.participant.competition.creator.id != requested_by.id:
+                raise PermissionDenied()
+        else:
+            # User making request must be owner of this submission and be granted
+            # download privilege by the competition owners.
+            if self.participant.user.id != requested_by.id:
+                raise PermissionDenied()
+            if file_has_restricted_access and self.phase.is_blind:
+                raise PermissionDenied()
+        file_type = 'text/plain' if file_ext == 'txt' else 'application/zip'
+        file_name = "{0}-{1}-{2}".format(self.participant.user.username, self.submission_number, key)
+        return getattr(self, file_attr), file_type, file_name
 
 class SubmissionResultGroup(models.Model):
     competition = models.ForeignKey(Competition)
@@ -704,13 +789,22 @@ class CompetitionDefBundle(models.Model):
         for p_num in comp_spec['phases']:
             phase_spec = comp_spec['phases'][p_num].copy()
             phase_spec['competition'] = comp
+
+            if 'leaderboard_management_mode' in phase_spec:
+                if not LeaderboardManagementMode.is_valid(phase_spec['leaderboard_management_mode']):
+                    msg = "Invalid leaderboard_management_mode ({0}) specified for phase {1}. Reverting to default."
+                    logger.warn(msg.format(phase_spec['leaderboard_management_mode'], p_num))
+                    phase_spec['leaderboard_management_mode'] = LeaderboardManagementMode.DEFAULT
+            else:
+                phase_spec['leaderboard_management_mode'] = LeaderboardManagementMode.DEFAULT
+
             if 'datasets' in phase_spec:
                 datasets = phase_spec['datasets']
                 del phase_spec['datasets']
             else:
                 datasets = {}
             if type(phase_spec['start_date']) is datetime.datetime.date:
-                phase_spec['start_date'] = datetime.datetime.combine(phase['start_date'], datetime.time())
+                phase_spec['start_date'] = datetime.datetime.combine(phase_spec['start_date'], datetime.time())
             phase, created = CompetitionPhase.objects.get_or_create(**phase_spec)
             logger.debug("CompetitionDefBundle::unpack created phase (pk=%s)", self.pk)
             # Evaluation Program
@@ -900,7 +994,7 @@ class SubmissionScore(models.Model):
         unique_together = (('result','scoredef'),)
 
     def save(self,*args,**kwargs):
-        if self.scoredef.computed is True and value:
+        if self.scoredef.computed is True and self.value:
             raise IntegrityError("Score is computed. Cannot assign a value")
         super(SubmissionScore,self).save(*args,**kwargs)
 
@@ -931,3 +1025,16 @@ class PhaseLeaderBoardEntry(models.Model):
     class Meta:
         unique_together = (('board', 'result'),)
 
+def add_submission_to_leaderboard(submission):
+    """
+    Adds the given submission to its leaderboard. It is the caller responsiblity to make
+    sure the submission is ready to be added (e.g. it's in the finished state).
+    """
+    lb,_ = PhaseLeaderBoard.objects.get_or_create(phase=submission.phase)
+    # Currently we only allow one submission into the leaderboard although the leaderboard
+    # is setup to accept multiple submissions from the same participant.
+    entries = PhaseLeaderBoardEntry.objects.filter(board=lb, result__participant=submission.participant)
+    for entry in entries:
+        entry.delete()
+    lbe, created = PhaseLeaderBoardEntry.objects.get_or_create(board=lb, result=submission)
+    return lbe, created

--- a/codalab/apps/web/static/js/Competition.js
+++ b/codalab/apps/web/static/js/Competition.js
@@ -263,7 +263,8 @@ var Competition;
             switch (index) {
                 case 0: if (response.status === "finished") { $(this).val("1"); } break;
                 case 1: $(this).html(response.submission_number.toString()); break;
-                case 2:
+                case 2: $(this).html(response.filename); break;
+                case 3:
                     var fmt = function (val) {
                         var s = val.toString();
                         if (s.length == 1) {
@@ -278,7 +279,7 @@ var Competition;
                     var s = fmt(dt.getSeconds());
                     $(this).html(d + " " + h + ":" + m + ":" + s);
                     break;
-                case 3: $(this).html(Competition.getSubmissionStatus(response.status)); break;
+                case 4: $(this).html(Competition.getSubmissionStatus(response.status)); break;
             }
         }
       );
@@ -332,14 +333,17 @@ var Competition;
                 });
             }
             else {
-                var status = $(nTr).find(".statusName").html();
+                var status = $.trim($(nTr).find(".statusName").html());
                 var btn = elem.find("button").addClass("hide");
-                if ($.trim(status) === "Submitting" || $.trim(status) === "Submitted" || $.trim(status) === "Running") {
+                if (status === "Submitting" || status === "Submitted" || status === "Running") {
                     btn.removeClass("hide");
                     btn.text("Refresh status")
                     btn.on('click', function () {
-                        Competition.updateSubmissionStatus($("#competitionId").val(), nTr.id, this)
+                        Competition.updateSubmissionStatus($("#competitionId").val(), nTr.id, this);
                     });
+                }
+                if (status === "Failed" || status === "Cancelled") {
+                    elem.find("a").removeClass("hide");
                 }
             }
             $(nTr).after(elem);
@@ -370,6 +374,7 @@ var Competition;
                 }
                 else if (data.status === 'failed' || data.status === 'cancelled') {
                     $(obj).addClass("hide");
+                    $(obj).parent().parent().find("a").removeClass("hide");
                 }
                 $(".competitionPreloader").hide();
             },

--- a/codalab/apps/web/tasks.py
+++ b/codalab/apps/web/tasks.py
@@ -13,7 +13,8 @@ from apps.jobs.models import (Job,
                               run_job_task,
                               JobTaskResult,
                               getQueue)
-from apps.web.models import (CompetitionSubmission,
+from apps.web.models import (add_submission_to_leaderboard,
+                             CompetitionSubmission,
                              CompetitionDefBundle,
                              CompetitionSubmissionStatus,
                              submission_prediction_output_filename,
@@ -52,7 +53,7 @@ def echo(text):
 
     Returns a Job object which can be used to track the progress of the operation.
     """
-    return Job.objects.create_and_dispatch_job('echo', { 'message': text })
+    return Job.objects.create_and_dispatch_job('echo', {'message': text})
 
 # Create competition
 
@@ -74,7 +75,7 @@ def create_competition_task(job_id, args):
         competition = competition_def.unpack()
         logger.info("Created competition for competition bundle (bundle_id=%s, job_id=%s, comp_id=%s)",
                     comp_def_id, job.id, competition.pk)
-        return JobTaskResult(status=Job.FINISHED, info={ 'competition_id': competition.pk })
+        return JobTaskResult(status=Job.FINISHED, info={'competition_id': competition.pk})
 
     run_job_task(job_id, create_it)
 
@@ -87,7 +88,7 @@ def create_competition(comp_def_id):
 
     Returns a Job object which can be used to track the progress of the operation.
     """
-    return Job.objects.create_and_dispatch_job('create_competition', { 'comp_def_id': comp_def_id })
+    return Job.objects.create_and_dispatch_job('create_competition', {'comp_def_id': comp_def_id})
 
 # Evaluate submissions in a competition
 
@@ -145,15 +146,15 @@ def predict(submission, job_id):
     lines = ["Standard error for submission #{0} by {1}.".format(submission.submission_number, username), ""]
     submission.stderr_file.save('stderr.txt', ContentFile('\n'.join(lines)))
     # Store workflow state
-    submission.execution_key = json.dumps({ 'predict' : job_id })
+    submission.execution_key = json.dumps({'predict' : job_id})
     submission.save()
     # Submit the request to the computation service
-    body = json.dumps({ "id" : job_id,
-                        "task_type": "run",
-                        "task_args": {
-                            "bundle_id" : submission.prediction_runfile.name,
-                            "container_name" : settings.BUNDLE_AZURE_CONTAINER,
-                            "reply_to" : settings.SBS_RESPONSE_QUEUE } })
+    body = json.dumps({"id" : job_id,
+                       "task_type": "run",
+                       "task_args": {
+                           "bundle_id" : submission.prediction_runfile.name,
+                           "container_name" : settings.BUNDLE_AZURE_CONTAINER,
+                           "reply_to" : settings.SBS_RESPONSE_QUEUE}})
     getQueue(settings.SBS_COMPUTE_QUEUE).send_message(body)
     # Update the submission object
     _set_submission_status(submission.id, CompetitionSubmissionStatus.SUBMITTED)
@@ -209,12 +210,12 @@ def score(submission, job_id):
     submission.execution_key = json.dumps(state)
     submission.save()
     # Submit the request to the computation service
-    body = json.dumps({ "id" : job_id,
-                        "task_type": "run",
-                        "task_args": {
-                            "bundle_id" : submission.runfile.name,
-                            "container_name" : settings.BUNDLE_AZURE_CONTAINER,
-                            "reply_to" : settings.SBS_RESPONSE_QUEUE } })
+    body = json.dumps({"id" : job_id,
+                       "task_type": "run",
+                       "task_args": {
+                           "bundle_id" : submission.runfile.name,
+                           "container_name" : settings.BUNDLE_AZURE_CONTAINER,
+                           "reply_to" : settings.SBS_RESPONSE_QUEUE}})
     getQueue(settings.SBS_COMPUTE_QUEUE).send_message(body)
     if has_generated_predictions == False:
         _set_submission_status(submission.id, CompetitionSubmissionStatus.SUBMITTED)
@@ -243,11 +244,11 @@ def update_submission_task(job_id, args):
         status: The new status string: 'running', 'finished' or 'failed'.
         job_id: The job ID used to track the progress of the evaluation.
         """
-        if (status == 'running'):
+        if status == 'running':
             _set_submission_status(submission.id, CompetitionSubmissionStatus.RUNNING)
             return Job.RUNNING
 
-        if (status == 'finished'):
+        if status == 'finished':
             result = Job.FAILED
             state = {}
             if len(submission.execution_key) > 0:
@@ -272,6 +273,11 @@ def update_submission_task(job_id, args):
                             logger.warning("Score %s does not exist (submission_id=%s)", label, submission.id)
                 logger.debug("Done processing scores... (submission_id=%s)", submission.id)
                 _set_submission_status(submission.id, CompetitionSubmissionStatus.FINISHED)
+                # Automatically submit to the leaderboard?
+                if submission.phase.is_blind:
+                    logger.debug("Adding to leaderboard... (submission_id=%s)", submission.id)
+                    add_submission_to_leaderboard(submission)
+                    logger.debug("Leaderboard updated with latest submission (submission_id=%s)", submission.id)
                 result = Job.FINISHED
             else:
                 logger.debug("update_submission_task entering scoring phase (pk=%s)", submission.pk)
@@ -286,7 +292,7 @@ def update_submission_task(job_id, args):
                     logger.exception("update_submission_task failed to enter scoring phase (pk=%s)", submission.pk)
             return result
 
-        if (status != 'failed'):
+        if status != 'failed':
             logger.error("Invalid status: %s (submission_id=%s)", status, submission.id)
         _set_submission_status(submission.id, CompetitionSubmissionStatus.FAILED)
 
@@ -308,7 +314,7 @@ def update_submission_task(job_id, args):
     def update_it(job):
         """Updates the database to reflect the state of the evaluation of the given competition submission."""
         logger.debug("Entering update_submission_task::update_it (job_id=%s)", job.id)
-        if (job.task_type != 'evaluate_submission'):
+        if job.task_type != 'evaluate_submission':
             raise ValueError("Job has incorrect task_type (job.task_type=%s)", job.task_type)
         task_args = job.get_task_args()
         submission_id = task_args['submission_id']
@@ -360,7 +366,7 @@ def evaluate_submission_task(job_id, args):
         except Exception:
             logger.exception("evaluate_submission_task dispatch failed (job_id=%s, submission_id=%s)",
                              job_id, submission_id)
-            update_submission_task(job_id, { 'status': 'failed' })
+            update_submission_task(job_id, {'status': 'failed'})
         logger.debug("evaluate_submission_task ends (job_id=%s)", job_id)
 
     submit_it()
@@ -374,6 +380,5 @@ def evaluate_submission(submission_id, is_scoring_only):
 
     Returns a Job object which can be used to track the progress of the operation.
     """
-    task_args = { 'submission_id': submission_id, 'predict': (not is_scoring_only) }
+    task_args = {'submission_id': submission_id, 'predict': (not is_scoring_only)}
     return Job.objects.create_and_dispatch_job('evaluate_submission', task_args)
-

--- a/codalab/apps/web/templates/web/competitions/_results_page.html
+++ b/codalab/apps/web/templates/web/competitions/_results_page.html
@@ -1,6 +1,12 @@
 {% if phase == None %}
 {% elif phase.is_future %}
-    <p>This phase of the competition has not started yet. Please check back later.</p>
+    <div class="columns">
+        <p>This phase of the competition has not started yet. Please check back later.</p>
+    </div>
+{% elif phase.is_blind %}
+    <div class="columns">
+        <p>Competition organizers have chosen to keep the leaderboard private. Please check back later.</p>
+    </div>
 {% else %}
     {% if groups|length > 0 %}
     <div class="small-12 columns icon_excel">

--- a/codalab/apps/web/templates/web/competitions/_submit_results_page.html
+++ b/codalab/apps/web/templates/web/competitions/_submit_results_page.html
@@ -18,40 +18,40 @@
     {% endif %}
     <div class="row">
       <div class="user_results">
-        {% if phase.is_active %}
-        <input type="hidden" id="phasestate" value='1' />
+        {% if phase.is_active and not phase.is_blind %}
+        <input type="hidden" id="phasestate" value="1" />
         {% else %}
-        <input type="hidden" id="phasestate" value='0' />
+        <input type="hidden" id="phasestate" value="0" />
         {% endif %}
         <table class="prevResultSubmission dataTable" id="user_results">
           <thead>
             <tr>
-                <th>Submission</th>
+                <th width="40px"></th>
+                <th>Filename</th>
                 <th>Submission date</th>
                 <th>Status</th>
-                <th width="40px"></th>
                 <th width="40px"></th>
                 <th width="40px"></th>
             </tr>
           </thead>
           <tbody>
-                {% if my_submissions|length_is:"0" %}
+                {% if submission_info_list|length_is:"0" %}
                 <tr class="noData">
                     <td class="tdDetails" colspan="6">No data available in table</td>
                 </tr>  
                 {% else %}  
-                {% for submission in my_submissions %}
-                <tr id="{{submission.id}}">
-                    {% if submission.status.codename == "finished" %}
+                {% for submission_info in submission_info_list %}
+                <tr id="{{submission_info.id}}">
+                    {% if submission_info.is_finished %}
                     <input type="hidden" name="state" value='1' />
                     {% else %}
                     <input type="hidden" name="state" value='0' />
                     {% endif %}
-                    <td>{{submission.submission_number}}</td>
-                    <td>{{submission.submitted_at|date:"m/d/Y H:i:s"}}</td>
-                    <td class="statusName">{{submission.status.name}}</td>
-                    <td></td>
-                    {% if submission.id == id_of_submission_in_leaderboard %}
+                    <td>{{submission_info.number}}</td>
+                    <td>{{submission_info.filename}}</td>
+                    <td>{{submission_info.submitted_at|date:"m/d/Y H:i:s"}}</td>
+                    <td class="statusName">{{submission_info.status_name}}</td>
+                    {% if submission_info.is_in_leaderboard %}
                     <td class="status submitted"><i class="fi-check"></i></td>
                     {% else %}
                     <td class="status not_submitted"></td>
@@ -70,9 +70,17 @@
                 <td class="tdDetails" colspan="6">
                     <div class="submission_details">
                         <div class="small-2 large-4 columns">
-                            <a href="/my/competition/submission/_/stdout.txt" target="_blank">Standard output log</a></br>
-                            <a href="/my/competition/submission/_/stderr.txt" target="_blank">Standard error log</a></br>
-                            <a href="/my/competition/submission/_/output.zip">Scoring Output</a>
+                            <a href="/my/competition/submission/_/input.zip">Download your submission</a></br>
+                            {% if phase.is_blind %}
+                                <a href="/my/competition/submission/_/stderr.txt" target="_blank" class="hide">View standard error log</a></br>
+                            {% else %}
+                                <a href="/my/competition/submission/_/stdout.txt" target="_blank">View standard output log</a></br>
+                                <a href="/my/competition/submission/_/stderr.txt" target="_blank">View standard error log</a></br>
+                                {% if not phase.is_scoring_only %}
+                                <a href="/my/competition/submission/_/prediction-output.zip">Download evaluation output from prediction step</a></br>
+                                {% endif %}
+                                <a href="/my/competition/submission/_/output.zip">Download evaluation output from scoring step</a>
+                            {% endif %}
                         </div>
                         <div class="small-2 large-4 columns preloader-handler"></div>
                         <div class="small-2 large-4 columns">
@@ -87,8 +95,8 @@
                 <input type="hidden" name="state" value="0" />
                 <td></td>
                 <td></td>
-                <td class="statusName"></td>
                 <td></td>
+                <td class="statusName"></td>
                 <td class="status not_submitted"></td>
                 <td><i class="fi-plus"></i></td>
             </tr>

--- a/codalab/apps/web/urls/my.py
+++ b/codalab/apps/web/urls/my.py
@@ -2,7 +2,6 @@ from django.conf.urls import patterns, include, url
 from django.contrib.auth.decorators import login_required
 from apps.web import views
 
-
 partials_patterns = patterns(
     '',
     url(r'^_competitions_managed$',
@@ -12,7 +11,7 @@ partials_patterns = patterns(
         login_required(views.MyCompetitionsEnteredPartial.as_view()),
         name='my_competitions_entered'),
     url(r'^(?P<phase_id>\d+)/(?P<participant_id>\d+)/_submission_results',
-        login_required(views.MySubmissionResultsPartial.as_view()), 
+        login_required(views.MySubmissionResultsPartial.as_view()),
         name='my_competition_submissions'),
 )
 
@@ -22,7 +21,7 @@ urlpatterns = patterns(
     url(r'^competition/(?P<competition_id>\d+)/participants/',
         views.MyCompetitionParticipantView.as_view(),
         name='my_competition_participants'),
-    url(r'^competition/submission/(?P<submission_id>\d+)/(?P<filetype>stdout.txt|stderr.txt|output.zip)$',
+    url(r'^competition/submission/(?P<submission_id>\d+)/(?P<filetype>stdout.txt|stderr.txt|input.zip|prediction-output.zip|output.zip)$',
         views.MyCompetitionSubmisisonOutput.as_view(),
         name='my_competition_output'),
     url(r'^_partials/', include(partials_patterns)),

--- a/codalab/apps/web/views.py
+++ b/codalab/apps/web/views.py
@@ -4,7 +4,9 @@ import csv
 
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 from django.core.urlresolvers import reverse, reverse_lazy
+from django.core.exceptions import ImproperlyConfigured
 from django.core.exceptions import ObjectDoesNotExist
+from django.core.exceptions import PermissionDenied
 from django.views.generic import View, TemplateView, DetailView, ListView, FormView, UpdateView, CreateView, DeleteView
 from django.views.generic.edit import FormMixin
 from django.views.generic.detail import SingleObjectMixin
@@ -40,7 +42,7 @@ def competition_index(request):
 @login_required
 def my_index(request):
     template = loader.get_template("web/my/index.html")
-    denied=models.ParticipantStatus.objects.get(codename=models.ParticipantStatus.DENIED)
+    denied = models.ParticipantStatus.objects.get(codename=models.ParticipantStatus.DENIED)
     context = RequestContext(request, {
         'my_competitions' : models.Competition.objects.filter(creator=request.user),
         'competitions_im_in' : request.user.participation.all().exclude(status=denied)
@@ -83,14 +85,14 @@ class CompetitionDelete(LoginRequiredMixin, DeleteView):
     model = models.Competition
     template_name = 'web/competitions/confirm-delete.html'
     success_url = '/my/#manage'
-    
+
 class CompetitionDetailView(DetailView):
     queryset = models.Competition.objects.all()
     model = models.Competition
     template_name = 'web/competitions/view.html'
 
     def get_context_data(self, **kwargs):
-        context = super(CompetitionDetailView,self).get_context_data(**kwargs)
+        context = super(CompetitionDetailView, self).get_context_data(**kwargs)
         competition = context['object']
         # This assumes the tabs were created in the correct order
         # TODO Add a rank, order by on ContentCategory
@@ -101,10 +103,10 @@ class CompetitionDetailView(DetailView):
                 tc = [x for x in pagecontent.pages.filter(category=category)]
             else:
                 tc = []
-            side_tabs[category] = tc 
+            side_tabs[category] = tc
         context['tabs'] = side_tabs
-        submissions=dict()
-        all_submissions=dict()
+        submissions = dict()
+        all_submissions = dict()
         try:
             if self.request.user.is_authenticated() and self.request.user in [x.user for x in competition.participants.all()]:
                 context['my_status'] = [x.status for x in competition.participants.all() if x.user == self.request.user][0].codename
@@ -126,15 +128,15 @@ class CompetitionDetailView(DetailView):
         except ObjectDoesNotExist:
             pass
 
-        return context     
- 
+        return context
+
 class CompetitionSubmissionsPage(LoginRequiredMixin, TemplateView):
     # Serves the table of submissions in the Participate tab of a competition.
     # Requires an authenticated user who is an approved participant of the competition.
     template_name = 'web/competitions/_submit_results_page.html'
 
     def get_context_data(self, **kwargs):
-        context = super(CompetitionSubmissionsPage,self).get_context_data(**kwargs)
+        context = super(CompetitionSubmissionsPage, self).get_context_data(**kwargs)
         context['phase'] = None
         competition = models.Competition.objects.get(pk=self.kwargs['id'])
         if self.request.user in [x.user for x in competition.participants.all()]:
@@ -142,17 +144,34 @@ class CompetitionSubmissionsPage(LoginRequiredMixin, TemplateView):
             if participant.status.codename == models.ParticipantStatus.APPROVED:
                 phase = competition.phases.get(pk=self.kwargs['phase'])
                 submissions = models.CompetitionSubmission.objects.filter(participant=participant, phase=phase)
-                context['my_submissions'] = submissions
+                # find which submission is in the leaderboard, if any and only if phase allows seeing results.
+                id_of_submission_in_leaderboard = -1
+                if not phase.is_blind:
+                    ids = [e.result.id for e in models.PhaseLeaderBoardEntry.objects.filter(board__phase=phase)
+                                       if e.result in submissions]
+                    if len(ids) > 0: id_of_submission_in_leaderboard = ids[0]
+                # map submissions to view data
+                submission_info_list = []
+                for submission in submissions:
+                    submission_info = {
+                        'id': submission.id,
+                        'number': submission.submission_number,
+                        'filename': submission.get_filename(),
+                        'submitted_at': submission.submitted_at,
+                        'status_name': submission.status.name,
+                        'is_finished': submission.status.codename == 'finished',
+                        'is_in_leaderboard': submission.id == id_of_submission_in_leaderboard
+                    }
+                    submission_info_list.append(submission_info)
+                context['submission_info_list'] = submission_info_list
                 context['phase'] = phase
-                ids = [ e.result.id for e in models.PhaseLeaderBoardEntry.objects.filter(board__phase=phase) if e.result in submissions ]
-                context['id_of_submission_in_leaderboard'] = ids[0] if len(ids) > 0 else -1
         return context
 
 class CompetitionResultsPage(TemplateView):
     # Serves the leaderboards in the Results tab of a competition.
     template_name = 'web/competitions/_results_page.html'
     def get_context_data(self, **kwargs):
-        context = super(CompetitionResultsPage,self).get_context_data(**kwargs)
+        context = super(CompetitionResultsPage, self).get_context_data(**kwargs)
         competition = models.Competition.objects.get(pk=self.kwargs['id'])
         phase = competition.phases.get(pk=self.kwargs['phase'])
         context['phase'] = phase
@@ -161,9 +180,11 @@ class CompetitionResultsPage(TemplateView):
 
 class CompetitionResultsDownload(View):
 
-    def get(self,request,*args,**kwargs):
+    def get(self, request, *args, **kwargs):
         competition = models.Competition.objects.get(pk=self.kwargs['id'])
         phase = competition.phases.get(pk=self.kwargs['phase'])
+        if phase.is_blind:
+            return HttpResponse(status=403)
         groups = phase.scores()
 
         csvfile = StringIO.StringIO()
@@ -172,7 +193,7 @@ class CompetitionResultsDownload(View):
         for group in groups:
             csvwriter.writerow([group['label']])
             csvwriter.writerow([])
-            
+
             headers = ["User"]
             sub_headers = [""]
             for header in group['headers']:
@@ -189,8 +210,8 @@ class CompetitionResultsDownload(View):
             if len(group['scores']) <= 0:
                 csvwriter.writerow(["No data available"])
             else:
-                for pk,scores in group['scores']:
-                    row = [ scores['username'] ]
+                for pk, scores in group['scores']:
+                    row = [scores['username']]
                     for v in scores['values']:
                         if 'rnk' in v:
                             row.append("%s (%s)" % (v['val'], v['rnk']))
@@ -200,7 +221,7 @@ class CompetitionResultsDownload(View):
 
             csvwriter.writerow([])
             csvwriter.writerow([])
-                    
+
         response = HttpResponse(csvfile.getvalue(), status=200, content_type="text/csv")
         response["Content-Disposition"] = "attachment; filename=test.csv"
 
@@ -211,12 +232,12 @@ class CompetitionResultsDownload(View):
 class MyIndex(LoginRequiredMixin):
     pass
 
-class MyCompetitionParticipantView(LoginRequiredMixin,ListView):
+class MyCompetitionParticipantView(LoginRequiredMixin, ListView):
     queryset = models.CompetitionParticipant.objects.all()
     template_name = 'web/my/participants.html'
 
-    def get_context_data(self,**kwargs):
-        ctx = super(MyCompetitionParticipantView,self).get_context_data(**kwargs)
+    def get_context_data(self, **kwargs):
+        ctx = super(MyCompetitionParticipantView, self).get_context_data(**kwargs)
         ctx['competition_id'] = self.kwargs.get('competition_id')
         return ctx
 
@@ -226,17 +247,17 @@ class MyCompetitionParticipantView(LoginRequiredMixin,ListView):
 ## Partials
 
 class CompetitionIndexPartial(TemplateView):
-    
-    def get_context_data(self,**kwargs):
+
+    def get_context_data(self, **kwargs):
         ## Currently gets all competitions
-        context = super(CompetitionIndexPartial,self).get_context_data(**kwargs)
-        per_page = self.request.GET.get('per_page',6)
-        page = self.request.GET.get('page',1)
+        context = super(CompetitionIndexPartial, self).get_context_data(**kwargs)
+        per_page = self.request.GET.get('per_page', 6)
+        page = self.request.GET.get('page', 1)
         clist = models.Competition.objects.all()
-        
+
         pgn = Paginator(clist, per_page)
         try:
-           competitions = pgn.page(page)
+            competitions = pgn.page(page)
         except PageNotAnInteger:
             # If page is not an integer, deliver first page.
             competitions = pgn.page(1)
@@ -261,15 +282,15 @@ class MyCompetitionsEnteredPartial(ListView):
 
     def get_queryset(self):
         return self.queryset.filter(user=self.request.user)
-        
+
 class MyCompetitionDetailsTab(TemplateView):
     template_name = 'web/my/_tab.html'
 
 class MySubmissionResultsPartial(TemplateView):
     template_name = 'web/my/_submission_results.html'
-    
-    def get_context_data(self,**kwargs):
-        ctx = super(MySubmissionResultsPartial,self).get_context_data(**kwargs)
+
+    def get_context_data(self, **kwargs):
+        ctx = super(MySubmissionResultsPartial, self).get_context_data(**kwargs)
 
         participant_id = kwargs.get('participant_id')
         participant = models.CompetitionParticipant.objects.get(pk=participant_id)
@@ -279,39 +300,46 @@ class MySubmissionResultsPartial(TemplateView):
 
         ctx['active_phase'] = phase
         ctx['my_active_phase_submissions'] = phase.submissions.filter(participant=participant)
-        
+
         return ctx
 
 class MyCompetitionSubmisisonOutput(LoginRequiredMixin, View):
-
-    def get(self,request,*args,**kwargs):
-        submission=models.CompetitionSubmission.objects.get(pk=kwargs.get('submission_id'))
+    """
+    This view serves the files associated with a submission.
+    """
+    def get(self, request, *args, **kwargs):
+        submission = models.CompetitionSubmission.objects.get(pk=kwargs.get('submission_id'))
         filetype = kwargs.get('filetype')
-        name, ext = filetype.split('.')
-        fileattr = name +'_file'
-        resp = None
-        if hasattr(submission, fileattr):
-            f = getattr(submission, fileattr)
-            if f:   
-                try:             
-                    resp = HttpResponse(f.read(), status=200, content_type='text/plain' if ext == 'txt' else 'application/zip')
-                except azure.WindowsAzureMissingResourceError:
-                    # for stderr.txt which does not exist when no errors have occurred
-                    # this may hide a true 404 in an unexpected circumstances
-                    resp = HttpResponse("", status=200, content_type='text/plain')
-                except:
-                    resp = HttpResponse("There was an error retrieving file '%s'. Please try again later or report the issue." % filetype, status=200, content_type='text/plain')
-        return resp if resp is not None else HttpResponse("The file '%s' does not exist." % filetype, status=200, content_type='text/plain')
-                                                           
-        
+        try:
+            file, file_type, file_name = submission.get_file_for_download(filetype, request.user, False)
+        except PermissionDenied:
+            return HttpResponse(status=403)
+        except ValueError:
+            return HttpResponse(status=400)
+        except:
+            return HttpResponse(status=500)
+        try:
+            response = HttpResponse(file.read(), status=200, content_type=file_type)
+            if file_type != 'text/plain':
+                response['Content-Type'] = 'application/zip'
+                response['Content-Disposition'] = 'attachment; filename="{0}"'.format(file_name)
+            return response
+        except azure.WindowsAzureMissingResourceError:
+            # for stderr.txt which does not exist when no errors have occurred
+            # this may hide a true 404 in unexpected circumstances
+            return HttpResponse("", status=200, content_type='text/plain')
+        except:
+            msg = "There was an error retrieving file '%s'. Please try again later or report the issue."
+            return HttpResponse(msg % filetype, status=200, content_type='text/plain')
+
 class VersionView(TemplateView):
-    template_name='web/project_version.html'
+    template_name = 'web/project_version.html'
 
     def get_context_data(self):
         import subprocess
         p = subprocess.Popen(["git", "rev-parse", "HEAD"], stdout=subprocess.PIPE)
         out, err = p.communicate()
-        ctx = super(VersionView,self).get_context_data()
+        ctx = super(VersionView, self).get_context_data()
         ctx['commit_hash'] = out
         tasks.echo("version is " + out)
         return ctx
@@ -326,7 +354,7 @@ class BundleListView(TemplateView):
     """
     template_name = 'web/bundles/bundle_list.html'
     def get_context_data(self, **kwargs):
-        context = super(BundleListView,self).get_context_data(**kwargs)
+        context = super(BundleListView, self).get_context_data(**kwargs)
         service = BundleService()
         results = service.items()
         context['bundles'] = results
@@ -338,8 +366,8 @@ class BundleDetailView(TemplateView):
     """
     template_name = 'web/bundles/bundle_detail.html'
     def get_context_data(self, **kwargs):
-        context = super(BundleDetailView,self).get_context_data(**kwargs)
-        uuid=kwargs.get('uuid')
+        context = super(BundleDetailView, self).get_context_data(**kwargs)
+        uuid = kwargs.get('uuid')
         service = BundleService()
         results = service.item(uuid)
         context['bundle'] = results


### PR DESCRIPTION
This commit adds the ability for competition organizers to hide results in a phase per #315 and enhances the submission table per #318.

**Creating a competition**

A new flag is introduced to define when competition results will appear to participants and how results of a submission are added to the leaderboard.

The name of the flag is **leaderboard_management_mode** and its possible values are:
- **default**: Emulates current behavior where results are visible to participants immediately. Participants select which entry to put in the leaderboard and the leaderboard is visible to all as soon as the phase is active.
- **hide_results**: Emulates the new behavior where results are hidden from participants until competition organizers make them available. Participants do not have the ability to select which entry goes to the leaderboard; instead the last successful submission is automatically added to the leaderboard. The participant has no visibility into the process. The leaderboard is also hidden.

Following is an excerpt from the competition definition YAML file:

```
phases:
    1:
        ...
        leaderboard_management_mode: "default"
        ...
    2:
        ...
        leaderboard_management_mode: "hide_results"
        ...
```

If the **leaderboard_management_mode** flag is not specified, then the value defaults to **default**.

**Changes to submission table**

The submission table has been modified to hide UI elements that are not applicable when the phase of the competition is setup to hide results.

In addition, some new requested elements have been added:
- Name of uploaded is shown in the FILENAME column of the table.
- Uploaded file can be downloaded back by expanding the corresponding row of the submission table and clicking the link "Download your submission"
- When results are visible, list of downloadable files now include the output from the prediction phase (when applicable) in addition to the output from the scoring phase.
- Downloaded files use a new naming convention of the form:
  
  ```
  <username>-<submission-number>-<input|prediction-output|output>.zip
  ```
  
  For example, if username is `john`, the scoring output for submission 3 will be named `john-3-output.zip`. The uploaded file can be re-downloaded and will then be named `john-3-input.zip`. Note that it would have been possible to also use the name of the original input file but we chose to use the same naming approach for all downloadable files. In addition, the API endpoint which serves the file is also accessible to competition organizers who may not be able to make sense of the user's original file name.

The object model for CompetitionSubmission has been modified to include a field which can hold a short description (256 chars max). However, the description field is not yet filled from the input bundle and is not surfaces in the UI. 

Here is a snapshot of the submission table when results are not hidden:
![sub-table-show-results](https://f.cloud.github.com/assets/3453398/2094363/da2c7676-8eca-11e3-994d-63a8b7d6ce41.jpg)

Here is a snapshot when results are hidden:
![sub-table-hide-results](https://f.cloud.github.com/assets/3453398/2094376/09e61354-8ecb-11e3-845f-20b560973942.jpg)

**Follow-up items**
- The on-going work on the competition editor will need to surface the new **leaderboard_management_mode** flag. Without the editing capability, the competition organizer cannot publish phase results.
- Documentation work: update competition creation doc and address note in work item #315 (="the competition owner needs to know they should not expose anything sensitive in stderr").  
- What date/time should be used in the submission table (local vs UTC)?
