### PR TITLE
Ignoring codalabconfig files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 codalab/config/generated
 codalab/static/**/**
 codalab/media/**/**
+**/**/.codalabconfig
 
 # Bundles prototype #
 #####################


### PR DESCRIPTION
The other commits should be squashed, they were housekeeping to get my master reverted to a good state from the project master.
