### PR TITLE
Add OAuth2 authorization server and token validation API for bundle server

### DIFF
--- a/codalab/apps/authenz/oauth.py
+++ b/codalab/apps/authenz/oauth.py
@@ -1,0 +1,64 @@
+"""
+Implements CodaLab-specific requirements for OAuth.
+"""
+
+import logging
+
+from oauth2_provider.models import Application
+from oauth2_provider.oauth2_validators import OAuth2Validator
+
+logger = logging.getLogger(__name__)
+
+#
+# Customized OAuth validator
+#
+
+class Validator(OAuth2Validator):
+    """
+    Customizes the default validator.
+    """
+
+    def validate_scopes(self, client_id, scopes, client, request, *args, **kwargs):
+        """
+        Ensure required scopes are permitted (as specified in the settings file)
+        """
+        allowed_scopes = []
+        if client.authorization_grant_type == Application.GRANT_CLIENT_CREDENTIALS:
+            allowed_scopes = ['token-validation']
+        return set(scopes).issubset(allowed_scopes)
+
+    def get_default_scopes(self, client_id, request, *args, **kwargs):
+        return []
+
+#
+# Helpers to create a default client to allow any CodaLab user to use their web site credentials
+# to connect their CLI client tool to the bundle service via OAuth protocol.
+#
+
+def cli_client_id(user):
+    """Provides the default CLI Client ID associated with the given user in the OAuth provider store."""
+    return 'cli_client_{0}'.format(user.username)
+
+def get_or_create_cli_client(user):
+    """
+    Get or create a default OAuth client that the given user can use to authorize his CLI application.
+    """
+    client_id = cli_client_id(user)
+    try:
+        logger.debug("Attempting to create cli client %s", client_id)
+        client, created = Application.objects.get_or_create(
+                            client_id=client_id,
+                            user=user,
+                            client_type=Application.CLIENT_CONFIDENTIAL,
+                            authorization_grant_type=Application.GRANT_PASSWORD,
+                            client_secret='',
+                            name=client_id)
+        if created:
+            logger.info("Created CLI client %s", client_id)
+        else:
+            logger.info("CLI client %s existed already", client_id)
+        return client, created
+    except:
+        logger.exception("Failed to create CLI client %s.", client_id)
+        return None, False
+

--- a/codalab/apps/authenz/urls.py
+++ b/codalab/apps/authenz/urls.py
@@ -1,0 +1,14 @@
+from django.conf.urls import (include, patterns, url)
+
+from apps.authenz import views
+
+def oauth2_include():
+    """Expose a limited set of endpoints from oauth2_provider.urls."""
+    urlconf, name, namespace = include('oauth2_provider.urls', namespace='oauth2_provider')
+    urlconf.urlpatterns = [p for p in urlconf.urlpatterns if p.name == 'token']
+    return (urlconf, name, namespace)
+
+urlpatterns = patterns('',
+    url(r'^validation', views.ValidationApi.as_view()),
+    url(r'', oauth2_include()),
+)

--- a/codalab/apps/authenz/views.py
+++ b/codalab/apps/authenz/views.py
@@ -1,1 +1,80 @@
-# Create your views here.
+"""
+View-related customatizations for auth.
+"""
+
+import json
+
+from django.dispatch import receiver
+from django.http import HttpResponse
+from django.utils.decorators import method_decorator
+from django.views.decorators.csrf import csrf_exempt
+
+from allauth.account.signals import user_signed_up
+from allauth.account.signals import user_logged_in
+
+from oauth2_provider.models import AccessToken
+from oauth2_provider.views.generic import ScopedProtectedResourceView
+
+from apps.authenz.oauth import get_or_create_cli_client
+
+#
+# Implements hooks for additional processing post sign-up and post log-in.
+#
+
+@receiver(user_signed_up)
+def new_user_signup(sender, **kwargs):
+    """
+    Handles bookkeeping after a user signs up.
+    """
+    user = kwargs['user']
+    get_or_create_cli_client(user)
+
+@receiver(user_logged_in)
+def on_user_logged_in(sender, **kwargs):
+    """
+    Handles bookkeeping after a user signs up.
+    """
+    user = kwargs['user']
+    # Backwards compatibility: do this for user who signed up before OAuth was added.
+    get_or_create_cli_client(user)
+
+#
+# OAuth token validation API
+#
+
+class ValidationApi(ScopedProtectedResourceView):
+    """
+    Translates an OAuth token into information about the associated CodaLab user.
+    """
+    required_scopes = ['token-validation']
+
+    @staticmethod
+    def _translate_token(token, scopes):
+        """
+        When users try to access resources, check that provided token is valid
+        """
+        if token is None or len(token) <= 0:
+            return {'code': 400}
+        try:
+            access_token = AccessToken.objects.select_related("application", "user").get(token=token)
+            if access_token.is_valid(scopes):
+                return {
+                    'code': 200,
+                    'user': {'id': access_token.user.id, 'name': access_token.user.username}
+                }
+            return {'code': 403}
+        except AccessToken.DoesNotExist:
+            return {'code': 404}
+        except:
+            return {'code': 500}
+
+    @method_decorator(csrf_exempt)
+    def dispatch(self, *args, **kwargs):
+        return super(ValidationApi, self).dispatch(*args, **kwargs)
+
+    def post(self, request, *args, **kwargs):
+        d = request.REQUEST
+        token = d['token'] if 'token' in d else None
+        scopes = d['scopes'] if 'scopes' in d else None
+        response_data = ValidationApi._translate_token(token, scopes)
+        return HttpResponse(json.dumps(response_data), content_type="application/json")

--- a/codalab/codalab/settings/base.py
+++ b/codalab/codalab/settings/base.py
@@ -209,13 +209,18 @@ class Base(Settings):
         'allauth',
         'allauth.account',
         'allauth.socialaccount',
-        
-        # 
+        'oauth2_provider',
+
+        # Search
         'haystack'
     )
 
     OPTIONAL_APPS = []
     INTERNAL_IPS = []
+
+    OAUTH2_PROVIDER = {
+        'OAUTH2_VALIDATOR_CLASS': 'apps.authenz.oauth.Validator',
+    }
 
     # Email Configuration
     EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
@@ -250,7 +255,7 @@ class Base(Settings):
     REST_FRAMEWORK = {
         'DEFAULT_RENDERER_CLASSES': (
             'rest_framework.renderers.JSONRenderer',
-            )
+        ),
     }
 
     #HAYSTACK_CONNECTIONS = {

--- a/codalab/codalab/urls.py
+++ b/codalab/codalab/urls.py
@@ -10,6 +10,7 @@ admin.autodiscover()
 urlpatterns = patterns('',
     url(r'', include('apps.web.urls')),
     url(r'^accounts/', include('allauth.urls')),
+    url(r'^clients/', include('apps.authenz.urls')),
     url(r'^api/', include('apps.api.routers')),
     url(r'^search/', include('haystack.urls')),
 
@@ -29,4 +30,4 @@ urlpatterns = patterns('',
 
     # JS Reverse for saner AJAX calls
     url(r'^jsreverse/$', 'django_js_reverse.views.urls_js', name='js_reverse')
-) 
+)

--- a/codalab/requirements/common.txt
+++ b/codalab/requirements/common.txt
@@ -3,13 +3,14 @@ pytz==2013b
 argparse
 django-configurations
 django-allauth==0.11.1
+oauthlib==0.6.1
+django-oauth-toolkit==0.6.1
 django-compressor==1.3
 django-config-gen==1.0.8
 django-extensions>=1.1.1
 django-guardian==1.1.1
 django-js-reverse>=0.2.0
 djangorestframework==2.3.6
-oauthlib==0.4.2
 python-openid==2.2.5
 python-ptrace==0.6.5
 requests==1.2.3


### PR DESCRIPTION
This PR enables the web site to act as an OAuth2 authorization server. This is a step to enable an instance of the CodaLab command line tool to connect securely with the bundle service.

**Workflow**

A picture of the expected authentication flow is given below. Labels in the picture mirror the OAuth 2 [terminology](http://tools.ietf.org/html/rfc6749#section-1.1). The key parties are:
- **Resource owner**: a CodaLab end-user with access-rights to a set of bundles stored in the CodaLab bundle server. Bundles are the protected resources.
- **Resource server**: CodaLab bundle server which stores and serves the protected bundles.
- **Client**: CLI tool.
- **Authorization server** (labelled **Authentication Server** on the picture): it is the service which authenticates the user.

![flow](https://f.cloud.github.com/assets/3453398/2239844/8f4c16d8-9c5e-11e3-96e4-b198bd1c24d4.jpg)

**Implementation details**

The OAuth authentication service is a component hosted in the Django web site. The implementation relies on a stack of two open-source libraries:
- [OAuthLib](https://oauthlib.readthedocs.org/en/latest/index.html) implements the core logic of the various OAuth flows but leaves parts of implementing an OAuth provider unspecified in order to not tie into a specific framework;
- [Django OAuth toolkit](https://django-oauth-toolkit.readthedocs.org/) extends OAuthLib by providing a pluggable Django app.

The two packages were added to the list of requirements `codalab/requirements/common.txt`:

```
oauthlib==0.6.1 
django-oauth-toolkit==0.6.1
```

CodaLab specific implementations is in app `apps.authenz`. Some things to note:
- `~/clients/token/` is the endpoint used by a client to authenticate and obtain a token. This is provided by Django OAuth toolkit. Additional endpoints provided by the toolkit are excluded since they are not needed today.
- `~/clients/validation/` is the endpoint used by a trusted bundle service to validate a token and translate it into an actual user ID (and eventually associated group IDs). The implementation of the endpoint is class `ValidationApi` in `apps\authenz\views.py`. Access to the endpoint is protected using `ScopedProtectedResourceView`, thus access is only granted when a valid token with scope `'token-validation` is presented.
- Scope validation happens in class `Validator` of `apps/authenz/oauth.py`. The validation should eventually rely on groups/roles that the user belongs too. For now, the implementation rely on the `authorization_grant_type` of the client app. In the current setup, a trusted bundle service will use "Client Credentials Grant" while other clients will use "Resource Owner Password Credentials Grant".
- For any CodaLab user, an OAuth client is automatically created to allow that user to access CodaLab with the CLI tool. The OAuth client is created after sign-up using the hook installed in `apps\authenz\views.py`. For backwards compatibility, we also check for the client's existence after a user logs in. I'll plan to remove the 'on login' hook after a script to update existing databases is written.

That's it for the implementation, now to some usage examples.

**Sample client code**

The code below shows how a client app can call the authentication service to obtain a token and to refresh a token. The code is straight Python and does not require additional libraries. The code assumes that the authentication service is running at the URL given by `get_token_url` (i.e. the CodaLab web site is running locally in this example). In addition, it is assumed that user `test1` is registered with the local CodaLab web site and that the password of `test1` is `abcdef`.

```
import json
import time
import urllib
import urllib2
from base64 import encodestring

username = 'test1'
password = 'abcdef'
appname = 'cli_client_{0}'.format(username)
get_token_url = 'http://localhost:1367/clients/token/'

# Get OAuth2 token using Resource Owner Password Credentials Grant 

headers = { 
    'Authorization': 'Basic {0}'.format(encodestring('%s:' % appname).replace('\n',''))
}
data = [
    ('grant_type', 'password'),
    ('username', username),
    ('password', password)
]
request = urllib2.Request(get_token_url, urllib.urlencode(data, True), headers)
try:
    response = urllib2.urlopen(request)
    token_info = json.load(response)
    print 'Token type: %s' % token_info['token_type']
    print 'Access token %s' % token_info['access_token']
    print 'Refresh token %s' % token_info['refresh_token']
    print 'Expires at %s' % (time.time() + int(token_info['expires_in']))
except urllib2.URLError as e:
    print e
except Exception as e:
    print e

# If token was acquired successfully, this shows how to refresh it.

if token_info:

    data = [
        ('grant_type', 'refresh_token'),
        ('refresh_token', token_info['refresh_token'])
    ]
    request = urllib2.Request(get_token_url, urllib.urlencode(data, True), headers)
    try:
        response = urllib2.urlopen(request)
        token_info = json.load(response)
        print 'Token type: %s' % token_info['token_type']
        print 'Access token %s' % token_info['access_token']
        print 'Refresh token %s' % token_info['refresh_token']
        print 'Expires at %s' % (time.time() + int(token_info['expires_in']))
    except urllib2.URLError as e:
        print e
    except Exception as e:
        print e
```

**Sample token validation code**

In this example, the trusted bundle server is the client calling the authentication server. First the trusted client authenticates itself and obtains a valid token. Notice that the request for the token is specifying the desired scope of `token-validation`.

The bundle service will receive a call from a CLI client. The CLI client will provide an OAuth token. In the second part of the example, the code shows how the trusted bundle service calls the validation endpoint `http://localhost:1367/clients/validation/` to translate the token received from the CLI client into a CodaLab user ID.

```
import json
import time
import urllib
import urllib2
from base64 import encodestring

# Trusted bundle service client starts by obtaining a valid token.

get_token_url = 'http://localhost:1367/clients/token/'
app_id = 'D9TqDG=nSNL;D!u4if=Tb?T3A1ppQ0Gx=fZT@A5p'
app_secret = 'BS7B;@IFM3yO0DXX??FlC1-q13Y@QxEQwjQOW9hrgxVKhBA'

app_sig = '%s:%s' % (app_id, app_secret)
headers = { 
    'Authorization': 'Basic {0}'.format(encodestring(app_sig).replace('\n',''))
}
data = [
    ('grant_type', 'client_credentials'),
    ('scope', 'token-validation')
]
request = urllib2.Request(get_token_url, urllib.urlencode(data, True), headers)
try:
    response = urllib2.urlopen(request)
    token_info = json.load(response)
    print 'Token type: %s' % token_info['token_type']
    print 'Access token %s' % token_info['access_token']
    print 'Expires at %s' % (time.time() + int(token_info['expires_in']))
except urllib2.URLError as e:
    print e
except Exception as e:
    print e

# Bundle service uses its access token to validate the access token that it received 
# from the CLI client.

service_auth_token = token_info['access_token']
user_auth_token = '54KVfvHgk960QY5UEJ7uPZLJcQaBSM'
validation_url = 'http://localhost:1367/clients/validation/'

headers = { 
    'Authorization': 'Bearer {0}'.format(service_auth_token)
}
data = [
    ('token', user_auth_token)
]
request = urllib2.Request(validation_url, urllib.urlencode(data, True), headers)
try:
    response = urllib2.urlopen(request)
    result = json.load(response)
    status_code = result['code'] if 'code' in result else 500
    if status_code == 200:
        print 'User ID: %s' % result['user']['id']
        print 'Username: %s' % result['user']['name']
    elif status_code == 403 or status_code == 404:
        print 'User credentials are not valid'
    else:
        print 'The token translation failed.'
except urllib2.URLError as e:
    print e
except Exception as e:
    print e
```

*\* Created a client for a trusted bundle service **

This needs to be done by running a script during deployment. The script will resemble this:

```
import sys, os.path, os

root_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))), "codalab")
sys.path.append(root_dir)

# Set things for django configurations
os.environ.setdefault("DJANGO_CONFIGURATION", "Dev")
os.environ.setdefault("DJANGO_SETTINGS_MODULE", "codalab.settings")

# Import the configuration
from configurations import importer
importer.install()

from django.contrib.auth import get_user_model
User = get_user_model()

user = User.objects.get(username='codalab')

from oauth2_provider.models import Application

client, created = Application.objects.get_or_create(
                    user=user,
                    client_type=Application.CLIENT_CONFIDENTIAL,
                    authorization_grant_type=Application.GRANT_CLIENT_CREDENTIALS,
                    name='Bundle service client')

print 'Client id: %s' % client.client_id
print 'Client secret: %s' % client.client_secret
```
