### PR TITLE
Add maintenance mode for deployments

### DIFF
--- a/codalab/apps/web/static/error/503.html
+++ b/codalab/apps/web/static/error/503.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>CodaLab</title>
+    <style>
+        body {
+            width: 50em;
+            margin: 0 auto;
+            font-family: Tahoma, Verdana, Arial, sans-serif;
+        }
+    </style>
+</head>
+<body>
+    <h1>The CodaLab site is being upgraded...</h1>
+    <p>Sorry, the page you are looking for is currently unavailable because the site is undergoing maintenance.</p>
+    <p>Please try again later. Thank you.</p>
+</body>
+</html>

--- a/codalab/apps/web/static/error/50x.html
+++ b/codalab/apps/web/static/error/50x.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>CodaLab</title>
+    <style>
+        body {
+            width: 50em;
+            margin: 0 auto;
+            font-family: Tahoma, Verdana, Arial, sans-serif;
+        }
+    </style>
+</head>
+<body>
+    <h1>The CodaLab site is currently unavailable.</h1>
+    <p>Sorry, the page you are looking for is currently unavailable.</p>
+    <p>Please try again later.</p>
+</body>
+</html>

--- a/codalab/codalab/settings/base.py
+++ b/codalab/codalab/settings/base.py
@@ -30,6 +30,10 @@ class Base(Settings):
     if 'CONFIG_HTTP_PORT' in os.environ:
         PORT = os.environ.get('CONFIG_HTTP_PORT')
 
+    MAINTENANCE_MODE=0
+    if 'MAINTENANCE_MODE' in os.environ:
+        MAINTENANCE_MODE = os.environ.get('MAINTENANCE_MODE')
+
     STARTUP_ENV = {
         'DJANGO_CONFIGURATION': os.environ['DJANGO_CONFIGURATION'],
         'DJANGO_SETTINGS_MODULE': os.environ['DJANGO_SETTINGS_MODULE'],

--- a/codalab/codalabtools/deploy/__init__.py
+++ b/codalab/codalabtools/deploy/__init__.py
@@ -255,6 +255,12 @@ class DeploymentConfig(BaseConfig):
         else:
             return ""
 
+    def getSslRewriteHosts(self):
+        """Gets the list of hosts for which HTTP requests are automatically re-written as HTTPS requests."""
+        if 'ssl' in self._svc and 'rewrite-hosts' in self._svc['ssl']:
+            return self._svc['ssl']['rewrite-hosts']
+        return ''
+
     def getBuildServiceName(self):
         """Gets the cloud service name for the build instance."""
         return "{0}build".format(self.getServicePrefix(), self.label)
@@ -875,6 +881,9 @@ class Deployment(object):
         allowed_hosts = ['{0}.cloudapp.net'.format(self.config.getServiceName())]
         allowed_hosts.extend(self.config.getWebHostnames())
         allowed_hosts.extend(['www.codalab.org', 'codalab.org'])
+        ssl_allowed_hosts = self.config.getSslRewriteHosts();
+        if len(ssl_allowed_hosts) == 0:
+            ssl_allowed_hosts = allowed_hosts
 
         storage_key = self._getStorageAccountKey(self.config.getServiceStorageAccountName())
         namespace = self.sbms.get_namespace(self.config.getServiceBusNamespace())
@@ -898,6 +907,7 @@ class Deployment(object):
             "    SSL_PORT = '443'",
             "    SSL_CERTIFICATE = '{0}'".format(self.config.getSslCertificateInstalledPath()),
             "    SSL_CERTIFICATE_KEY = '{0}'".format(self.config.getSslCertificateKeyInstalledPath()),
+            "    SSL_ALLOWED_HOSTS = {0}".format(ssl_allowed_hosts),
             "",
             "    DEFAULT_FILE_STORAGE = 'codalab.azure_storage.AzureStorage'",
             "    AZURE_ACCOUNT_NAME = '{0}'".format(self.config.getServiceStorageAccountName()),

--- a/codalab/config/templates/nginx.conf
+++ b/codalab/config/templates/nginx.conf
@@ -12,7 +12,7 @@ upstream bundleservice {
 {% if SSL_CERTIFICATE|length > 0 %}
 server {
     listen {{PORT}};
-    server_name {{ ALLOWED_HOSTS|join:" " }}{% if SERVER_NAME not in ALLOWED_HOSTS %} {{SERVER_NAME}}{% endif %};
+    server_name {{ SSL_ALLOWED_HOSTS|join:" " }};
     location / {
         rewrite ^ https://$server_name$request_uri permanent;
     }
@@ -20,6 +20,8 @@ server {
 {% endif %}
 
 server {
+
+    set $maintenance {{MAINTENANCE_MODE}};
 
     {% if SSL_CERTIFICATE|length > 0 %}
     listen {{SSL_PORT}} ssl;
@@ -54,6 +56,9 @@ server {
     }
 
     location / {
+        if ($maintenance = 1) {
+            return 503;
+        }
         uwsgi_pass  django;
         # Up timeout from default 60 to 1200 seconds (20 minutes?) to see if it helps avoid 504's
         uwsgi_read_timeout 1200;
@@ -75,5 +80,12 @@ server {
         uwsgi_param   X-Real-IP            $remote_addr;
         uwsgi_param   X-Forwarded-For      $proxy_add_x_forwarded_for;
         uwsgi_param   X-Forwarded-Proto    $http_x_forwarded_proto;
+    }
+
+    error_page 503 /error/503.html;
+    error_page 502 /error/50x.html;
+    location ^~ /error/ {
+        internal;
+        root /home/azureuser/deploy/codalab/static;
     }
 }


### PR DESCRIPTION
Add a maintenance command in the fab file in order to show a friendly web page when the web site is being updated. To update the site, a possible sequence of fab commands is:

```
build
push_build
maintenance:begin
supervisor_stop
deploy_web
supervisor
maintenance:end
```

Note that the `maintenance` command includes a call to `nginx_restart`.

The PR also includes an additional configuration parameter to explicit name the hosts for which http requests will automatically be re-written as https request.
