### PR TITLE
Fix #410 Score headers with explicit ordering not aligning

### DIFF
--- a/codalab/apps/web/templates/web/competitions/_results_page.html
+++ b/codalab/apps/web/templates/web/competitions/_results_page.html
@@ -1,3 +1,5 @@
+{% load codalab %}
+
 {% if phase == None %}
 {% elif phase.is_future %}
     <div class="columns">
@@ -53,12 +55,16 @@
             <tr>
                 <td class="row-position">{{pk}}</td>
                 <td>{{scoredata.username}}</td>
-                {% for v in scoredata.values %}
-                    {% if 'rnk' in v %}
-                        <td {% if group.selection_key == v.name %} class="column-selected" {% endif %} name={{v.name}}>{{v.val}} (<span class="rank">{{v.rnk}}</span>)</td>
-                    {% else %}
-                        <td {% if group.selection_key == v.name %} class="column-selected" {% endif %} name={{v.name}}>{{v.val}} <span class="rank hide">{{v.hidden_rnk}}</span></td>
-                    {% endif %}
+                {% for head in group.headers %}
+                    {% for head_or_sub in head|get_array_or_attr:'subs' %}
+                        {% with scoredata.values|get_by_name:head_or_sub.key|first as v %}
+                            {% if 'rnk' in v %}
+                                <td {% if group.selection_key == v.name %} class="column-selected" {% endif %} name={{v.name}}>{{v.val}} (<span class="rank">{{v.rnk}}</span>)</td>
+                            {% else %}
+                                <td {% if group.selection_key == v.name %} class="column-selected" {% endif %} name={{v.name}}>{{v.val}} <span class="rank hide">{{v.hidden_rnk}}</span></td>
+                            {% endif %}
+                        {% endwith %}
+                    {% endfor %}
                 {% endfor %}
             </tr>
             {% endfor %}

--- a/codalab/apps/web/templatetags/codalab.py
+++ b/codalab/apps/web/templatetags/codalab.py
@@ -27,3 +27,14 @@ def get_type(value):
 @register.filter
 def get_item(dictionary, key):
     return dictionary.get(key)
+
+@register.filter
+def get_by_name(dictionary, key):
+    return filter(lambda x: x['name'] == key, dictionary)
+
+@register.filter
+def get_array_or_attr(elem, attribute):
+    if attribute in elem and len(elem[attribute]) > 0:
+        return elem[attribute]
+    else:
+        return [elem]


### PR DESCRIPTION
Fix https://github.com/codalab/codalab/issues/410.

Rendering headers and values is based on two different structures that maintain the same order when the competition does not specify an explicit order. One fix would be to change the API to return the same ordering for these two structures in all cases; however, since they are different structures, it is harder to enforce this peculiarity. Therefore, the proposed fix is to render headers and score values using the same order, the headers order.
