### PR TITLE
Add API in the auth provider to resolve user names from the CLI.

### DIFF
--- a/codalab/apps/authenz/urls.py
+++ b/codalab/apps/authenz/urls.py
@@ -10,5 +10,6 @@ def oauth2_include():
 
 urlpatterns = patterns('',
     url(r'^validation', views.ValidationApi.as_view()),
+    url(r'^info', views.InfoApi.as_view()),
     url(r'', oauth2_include()),
 )

--- a/codalab/apps/authenz/views.py
+++ b/codalab/apps/authenz/views.py
@@ -15,6 +15,7 @@ from allauth.account.signals import user_logged_in
 from oauth2_provider.models import AccessToken
 from oauth2_provider.views.generic import ScopedProtectedResourceView
 
+from apps.authenz.models import ClUser
 from apps.authenz.oauth import get_or_create_cli_client
 
 #
@@ -77,4 +78,46 @@ class ValidationApi(ScopedProtectedResourceView):
         token = d['token'] if 'token' in d else None
         scopes = d['scopes'] if 'scopes' in d else None
         response_data = ValidationApi._translate_token(token, scopes)
+        return HttpResponse(json.dumps(response_data), content_type="application/json")
+
+
+class InfoApi(ScopedProtectedResourceView):
+    """
+    Translates a list of names into information about CodaLab users with matching names.
+    """
+    required_scopes = ['token-validation']
+
+    @staticmethod
+    def _translate_names(names):
+        """
+        Performs translation of list of names to list of user dict.
+        """
+        if names is None or type(names) is not list or len(names) == 0:
+            return {'code': 400}
+        for name in names:
+            if type(name) not in (str, unicode) or len(name) < 1:
+                return {'code': 400}
+        try:
+            users = ClUser.objects.filter(username__in=names)
+            user_dict = {}
+            for user in users:
+                user_dict[user.username] = user
+            user_list = []
+            for name in names:
+                if name in user_dict:
+                    user = user_dict[name]
+                    user_list.append({'name': name, 'id': user.id, 'active': user.is_active})
+                else:
+                    user_list.append({'name': name})
+            return {'code': 200, 'users': user_list}
+        except:
+            return {'code': 500}
+
+    @method_decorator(csrf_exempt)
+    def dispatch(self, *args, **kwargs):
+        return super(InfoApi, self).dispatch(*args, **kwargs)
+
+    def post(self, request, *args, **kwargs):
+        names = request.POST.getlist('names') if 'names' in request.POST else None
+        response_data = InfoApi._translate_names(names)
         return HttpResponse(json.dumps(response_data), content_type="application/json")


### PR DESCRIPTION
Sample usage:

```
headers = { 
    'Authorization': 'Bearer {0}'.format(service_auth_token)
}
data = [
    ('names', ('test1', 'notthere', 'user1')) # list of user names to resolve
]
info_url = 'http://localhost:8000/clients/info/'
request = urllib2.Request(info_url, urllib.urlencode(data, True), headers)
try:
    response = urllib2.urlopen(request)
    result = json.load(response)
    status_code = result['code'] if 'code' in result else 500
    if status_code == 200:
        for user in result['users']:
            print user['name']
            if 'id' in user:
                print "  id: %s" % (user['id'])
                print "  active: %s" % (user['active'])
            else:
                print "  is not a user"
    else:
        print 'The call failed.'
except urllib2.URLError as e:
    print e
except Exception as e:
    print e
```
