### PR TITLE
Adds "is auto submission" metadata 

### DIFF
--- a/codalab/codalabtools/compute/worker.py
+++ b/codalab/codalabtools/compute/worker.py
@@ -283,7 +283,7 @@ def get_run_func(config):
            # Try cleaning-up temporary directory
            try:
                os.chdir(current_dir)
-               #shutil.rmtree(root_dir)
+               shutil.rmtree(root_dir)
            except:
                logger.exception("Unable to clean-up local folder %s (task_id=%s)", root_dir, task_id)
     return run


### PR DESCRIPTION
Allows scoring program to see "is this an automatic submission?" via metadata.

`automatic-submission: True/False` added to `/input/metadata`

Resolves issue #498
## Functional Review
- [ ] Functional review completed by @_________
