### PR TITLE
Allow more HTML pages in competition.yaml

### DIFF
--- a/codalab/apps/web/models.py
+++ b/codalab/apps/web/models.py
@@ -926,14 +926,24 @@ class CompetitionDefBundle(models.Model):
         Page.objects.create(category=details_category, container=pc,  codename="terms_and_conditions", competition=comp,
                                    label="Terms and Conditions", rank=2, html=zf.read(comp_spec['html']['terms']))
 
+        default_pages = ('overview', 'evaluation', 'terms', 'data')
+
+        for page_name, page_data in comp_spec['html'].items():
+            if page_name not in default_pages:
+                Page.objects.create(
+                    category=details_category,
+                    container=pc,
+                    codename=page_name,
+                    competition=comp,
+                    label=page_name,
+                    rank=2,
+                    html=zf.read(page_data)
+                )
+
         participate_category = ContentCategory.objects.get(name="Participate")
         Page.objects.create(category=participate_category, container=pc,  codename="get_data", competition=comp,
                                    label="Get Data", rank=0, html=zf.read(comp_spec['html']['data']))
         Page.objects.create(category=participate_category, container=pc,  codename="submit_results", label="Submit / View Results", rank=1, html="")
-
-
-
-
 
         logger.debug("CompetitionDefBundle::unpack created competition pages (pk=%s)", self.pk)
 


### PR DESCRIPTION
Resolves Issue #494
## Functional Review

Add extra pages to your `competition.yaml`, like so:

```
description: An example competition where submissions should output "Hello World!"
force_submission_to_leaderboard: true
has_registration: true
html:
  data: data.html
  evaluation: evaluation.html
  overview: overview.html
  terms: terms_and_conditions.html
  extra: overview.html
image: logo.jpg
...
```
