### PR TITLE
removes console email from base... can do it in local.py

### DIFF
--- a/codalab/codalab/settings/base.py
+++ b/codalab/codalab/settings/base.py
@@ -391,4 +391,4 @@ class DevBase(Base):
     }
 
     # Send e-mails to the console during development
-    EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+    #EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'


### PR DESCRIPTION
Previously `DevBase` had `EMAIL_BACKEND` set to `'django.core.mail.backends.console.EmailBackend'`, which is what the staging server used. Hopefully this fixes problems with emails not sending.
