### PR TITLE
#557 render contents as a blockquote

### DIFF
--- a/codalab/apps/web/static/css/worksheets.css
+++ b/codalab/apps/web/static/css/worksheets.css
@@ -68,6 +68,20 @@
 #worksheet-content .type-markup ol {
   list-style-type:decimal;
 }
+#worksheet-content .type-contents blockquote {
+  padding: 1em 0 1em 1.5em;
+  border-left:4px solid #eee;
+}#worksheet-content .type-contents:not(.focused) blockquote{
+  background-color:#fafafa;
+
+}
+#worksheet-content .type-contents blockquote p {
+  white-space: pre;
+  color:#555;
+  margin:0;
+  font-size:14px;
+  line-height:1.5em;
+}
 table.table {
   border-collapse: separate;
   border-spacing: 2px;

--- a/codalab/apps/web/static/js/worksheet/contents_bundle_interface.js
+++ b/codalab/apps/web/static/js/worksheet/contents_bundle_interface.js
@@ -1,0 +1,19 @@
+/** @jsx React.DOM */
+
+var ContentsBundle = React.createClass({
+    getInitialState: function(){
+        return this.props.item.state;
+    },
+    render: function() {
+        var contents = this.state.interpreted.map(function(item){
+            return item.replace(/%\s/, '');
+        });
+        contents = contents.join('');
+        // contents = contents.replace(/%\s/g, '');
+        return(
+            <blockquote>
+                <p dangerouslySetInnerHTML={{__html: contents}} />
+            </blockquote>
+        );
+    } // end of render function
+}); //end of  ContentsBundle

--- a/codalab/apps/web/static/js/worksheet/markdown_bundle_interface.js
+++ b/codalab/apps/web/static/js/worksheet/markdown_bundle_interface.js
@@ -56,7 +56,7 @@ var MarkdownBundle = React.createClass({
         // http://facebook.github.io/react/docs/special-non-dom-attributes.html
         // http://facebook.github.io/react/docs/tags-and-attributes.html#html-attributes
         return(
-            <span dangerouslySetInnerHTML={{__html: text}} onKeyDown={this.handleMarkdownKeyboardShortcuts} />
+            <div dangerouslySetInnerHTML={{__html: text}} onKeyDown={this.handleMarkdownKeyboardShortcuts} />
         );
         }
     } // end of render function

--- a/codalab/apps/web/static/js/worksheet/worksheet_interface.js
+++ b/codalab/apps/web/static/js/worksheet/worksheet_interface.js
@@ -204,6 +204,12 @@ var WorksheetItemFactory = React.createClass({
                 );
                 break;
 
+            case 'contents':
+                rendered_bundle = (
+                    <ContentsBundle item={item} />
+                );
+                break;
+
             default: // render things we don't know in bold for now
                 rendered_bundle = (
                     <div>

--- a/codalab/apps/web/templates/web/worksheets/detail.html
+++ b/codalab/apps/web/templates/web/worksheets/detail.html
@@ -46,6 +46,7 @@
     <script type="text/jsx" src="{{ STATIC_URL }}js/worksheet/inline_bundle_interface.js"></script>
     <script type="text/jsx" src="{{ STATIC_URL }}js/worksheet/table_bundle_interface.js"></script>
     <script type="text/jsx" src="{{ STATIC_URL }}js/worksheet/markdown_bundle_interface.js"></script>
+    <script type="text/jsx" src="{{ STATIC_URL }}js/worksheet/contents_bundle_interface.js"></script>
 
 <script>
 MathJax.Hub.Config({


### PR DESCRIPTION
- strip initial '%' from each line for display purposes (will restore for editing)
- join items in contents array (lines) into a string
- style as blockquote with border, indent, slightly lighter background
- use whitespace: pre in css to preserve indents and linebreaks
- also changed markdown bundles to render inside a div instead of a span because a block-level element is more appropriate
