### PR TITLE
#627 Render record bundles as key:value tables

### DIFF
--- a/codalab/apps/web/static/js/worksheet/record_bundle_interface.js
+++ b/codalab/apps/web/static/js/worksheet/record_bundle_interface.js
@@ -1,0 +1,72 @@
+/** @jsx React.DOM */
+
+var RecordBundle = React.createClass({
+    getInitialState: function(){
+        var state = this.props.item.state;
+        state.rowFocusIndex = 0;
+        state.handleKeyboardShortcuts = this.handleKeyboardShortcuts;
+        return state;
+    },
+    handleKeyboardShortcuts: function(event){
+        var key = keyMap[event.keyCode];
+        var index = this.state.rowFocusIndex;
+        var rowsInTable = this.props.item.state.interpreted[1].length;
+        if(typeof key !== 'undefined'){
+            event.preventDefault();
+            switch (key) {
+                case 'up':
+                case 'k':
+                    event.preventDefault();
+                    index = Math.max(this.state.rowFocusIndex - 1, 0);
+                    if(this.state.rowFocusIndex === 0){
+                        ws_interactions.state.worksheetFocusIndex--;
+                        ws_broker.fire('updateState');
+                    }else {
+                        this.setState({rowFocusIndex: index});
+                    }
+                    break;
+                case 'down':
+                case 'j':
+                    event.preventDefault();
+                    index = Math.min(this.state.rowFocusIndex + 1, rowsInTable);
+                    if(index == rowsInTable){
+                        ws_interactions.state.worksheetFocusIndex++;
+                        ws_broker.fire('updateState');
+                    }else {
+
+                        this.setState({rowFocusIndex: index});
+                    }
+                    break;
+                default:
+                    return true;
+                }
+            } else {
+                return true;
+            }
+        event.stopPropagation();
+    },
+    render: function() {
+        var header = this.state.interpreted[0];
+        var focusIndex = this.state.rowFocusIndex;
+        var k = header[0];
+        var v = header[1];
+        var items = this.state.interpreted[1].map(function(item, index){
+            var focused = index === focusIndex;
+            return(
+                <tr key={index} focused={focused} className={focused ? 'focused' : ''}>
+                    <th>
+                        {item[k]}
+                    </th>
+                    <td>
+                        {item[v]}
+                    </td>
+                </tr>
+            )
+        });
+        return (
+            <table className="table table-record">
+                {items}
+            </table>
+        );
+    } // end of render function
+}); //end of  RecordBundle

--- a/codalab/apps/web/static/js/worksheet/worksheet_interface.js
+++ b/codalab/apps/web/static/js/worksheet/worksheet_interface.js
@@ -46,7 +46,7 @@ var Worksheet = React.createClass({
     handleKeyboardShortcuts: function(event) {
         var content = this.state.content;
         var focusedItem = content.items[this.state.interactions.worksheetFocusIndex];
-        if(this.state.interactions.worksheetKeyboardShortcuts && focusedItem.state.mode !== 'table'){
+        if(this.state.interactions.worksheetKeyboardShortcuts && focusedItem.state.mode !== 'table' && focusedItem.state.mode !== 'record'){
             var key = keyMap[event.keyCode];
             var index = this.state.interactions.worksheetFocusIndex;
             if(typeof key !== 'undefined'){
@@ -80,7 +80,7 @@ var Worksheet = React.createClass({
                 return true;
             }
         } else {
-            if(focusedItem.state.mode == 'table'){
+            if(focusedItem.state.mode == 'table' || focusedItem.state.mode == 'record'){
                 focusedItem.state.handleKeyboardShortcuts(event);
             }
             return true;
@@ -207,6 +207,12 @@ var WorksheetItemFactory = React.createClass({
             case 'contents':
                 rendered_bundle = (
                     <ContentsBundle item={item} />
+                );
+                break;
+
+            case 'record':
+                rendered_bundle = (
+                    <RecordBundle item={item} />
                 );
                 break;
 

--- a/codalab/apps/web/templates/web/worksheets/detail.html
+++ b/codalab/apps/web/templates/web/worksheets/detail.html
@@ -47,6 +47,7 @@
     <script type="text/jsx" src="{{ STATIC_URL }}js/worksheet/table_bundle_interface.js"></script>
     <script type="text/jsx" src="{{ STATIC_URL }}js/worksheet/markdown_bundle_interface.js"></script>
     <script type="text/jsx" src="{{ STATIC_URL }}js/worksheet/contents_bundle_interface.js"></script>
+    <script type="text/jsx" src="{{ STATIC_URL }}js/worksheet/record_bundle_interface.js"></script>
 
 <script>
 MathJax.Hub.Config({


### PR DESCRIPTION
- Reused much of the code from table_bundle_interface.js, including keyboard shortcuts to navigate rows
- the key and value named in the first array of the interpreted object are variable; that is, key does not necessarily have to be "key," and value does not necessarily have to be "value," but there must be a designator of each.
