### PR TITLE
Feature/560 delete worksheet items

### DIFF
--- a/codalab/apps/web/static/css/worksheets.css
+++ b/codalab/apps/web/static/css/worksheets.css
@@ -11,6 +11,13 @@
 #worksheet-content {
   line-height:1.2em;
 }
+#worksheet-content .hidden {
+  display:none;
+}
+#worksheet-content .empty-worksheet {
+  color:#a4a4a4;
+  text-align:center;
+}
 #worksheet-content .worksheet-name {
   border-bottom:1px solid #ddd;
   margin-bottom:1.875em;

--- a/codalab/apps/web/static/js/worksheet/markdown_bundle_interface.js
+++ b/codalab/apps/web/static/js/worksheet/markdown_bundle_interface.js
@@ -13,7 +13,7 @@ var MarkdownBundle = React.createClass({
                     this._owner.props.onExitEdit();
                     break;
                 case 'enter':
-                    if(event.ctrlKey || (isMac && event.metaKey)){
+                    if(event.ctrlKey || event.metaKey){
                         event.preventDefault();
                         this.saveEditedItem(event.target);
                     }

--- a/codalab/apps/web/static/js/worksheet/record_bundle_interface.js
+++ b/codalab/apps/web/static/js/worksheet/record_bundle_interface.js
@@ -1,50 +1,7 @@
 /** @jsx React.DOM */
 
 var RecordBundle = React.createClass({
-    getInitialState: function(){
-        var state = this.props.item.state;
-        state.rowFocusIndex = 0;
-        state.handleKeyboardShortcuts = this.handleKeyboardShortcuts;
-        return state;
-    },
-    handleKeyboardShortcuts: function(event){
-        var key = keyMap[event.keyCode];
-        var index = this.state.rowFocusIndex;
-        var rowsInTable = this.props.item.state.interpreted[1].length;
-        if(typeof key !== 'undefined'){
-            event.preventDefault();
-            switch (key) {
-                case 'up':
-                case 'k':
-                    event.preventDefault();
-                    index = Math.max(this.state.rowFocusIndex - 1, 0);
-                    if(this.state.rowFocusIndex === 0){
-                        ws_interactions.state.worksheetFocusIndex--;
-                        ws_broker.fire('updateState');
-                    }else {
-                        this.setState({rowFocusIndex: index});
-                    }
-                    break;
-                case 'down':
-                case 'j':
-                    event.preventDefault();
-                    index = Math.min(this.state.rowFocusIndex + 1, rowsInTable);
-                    if(index == rowsInTable){
-                        ws_interactions.state.worksheetFocusIndex++;
-                        ws_broker.fire('updateState');
-                    }else {
-
-                        this.setState({rowFocusIndex: index});
-                    }
-                    break;
-                default:
-                    return true;
-                }
-            } else {
-                return true;
-            }
-        event.stopPropagation();
-    },
+    mixins: [TableMixin],
     render: function() {
         var header = this.state.interpreted[0];
         var focusIndex = this.state.rowFocusIndex;
@@ -65,7 +22,9 @@ var RecordBundle = React.createClass({
         });
         return (
             <table className="table table-record">
-                {items}
+                <tbody>
+                    {items}
+                </tbody>
             </table>
         );
     } // end of render function

--- a/codalab/apps/web/static/js/worksheet/table_bundle_interface.js
+++ b/codalab/apps/web/static/js/worksheet/table_bundle_interface.js
@@ -1,50 +1,7 @@
 /** @jsx React.DOM */
 
 var TableBundle = React.createClass({
-    getInitialState: function(){
-        var state = this.props.item.state;
-        state.rowFocusIndex = 0;
-        state.handleKeyboardShortcuts = this.handleKeyboardShortcuts;
-        return state;
-    },
-    handleKeyboardShortcuts: function(event){
-        var key = keyMap[event.keyCode];
-        var index = this.state.rowFocusIndex;
-        var rowsInTable = this.props.item.state.interpreted[1].length;
-        if(typeof key !== 'undefined'){
-            event.preventDefault();
-            switch (key) {
-                case 'up':
-                case 'k':
-                    event.preventDefault();
-                    index = Math.max(this.state.rowFocusIndex - 1, 0);
-                    if(this.state.rowFocusIndex == 0){
-                        ws_interactions.state.worksheetFocusIndex--;
-                        ws_broker.fire('updateState');
-                    }else {
-                        this.setState({rowFocusIndex: index});
-                    }
-                    break;
-                case 'down':
-                case 'j':
-                    event.preventDefault();
-                    index = Math.min(this.state.rowFocusIndex + 1, rowsInTable);
-                    if(index == rowsInTable){
-                        ws_interactions.state.worksheetFocusIndex++;
-                        ws_broker.fire('updateState');
-                    }else {
-
-                        this.setState({rowFocusIndex: index});
-                    }
-                    break;
-                default:
-                    return true;
-                }
-            } else {
-                return true;
-            }
-        event.stopPropagation();
-    },
+    mixins: [TableMixin],
     render: function() {
         var bundle_info = this.state.bundle_info;
         var header_items = this.state.interpreted[0];

--- a/codalab/apps/web/static/js/worksheet/worksheet_interface.js
+++ b/codalab/apps/web/static/js/worksheet/worksheet_interface.js
@@ -1,5 +1,4 @@
 /** @jsx React.DOM */
-var isMac = window.navigator.platform.toString().indexOf('Mac') >= 0;
 
 var keyMap = {
     13: "enter",
@@ -59,7 +58,6 @@ var Worksheet = React.createClass({
                     case 'k':
                         event.preventDefault();
                         index = Math.max(this.state.interactions.worksheetFocusIndex - 1, 0);
-                        console.log(index);
                         ws_interactions.state.worksheetFocusIndex = index;
                         break;
                     case 'down':
@@ -141,10 +139,15 @@ var Worksheet = React.createClass({
         this.bindEvents();
     },
     componentDidUpdate: function(){
-        var focusIndex = this.state.interactions.worksheetFocusIndex; // shortcut
-        var itemNode = this.refs['item' + focusIndex].getDOMNode();
-        if(itemNode.offsetTop > window.innerHeight / 2){
-            window.scrollTo(0, itemNode.offsetTop - (window.innerHeight / 2));
+        if(this.state.content.items.length){
+            var focusIndex = this.state.interactions.worksheetFocusIndex; // shortcut
+            var itemNode = this.refs['item' + focusIndex].getDOMNode();
+            if(itemNode.offsetTop > window.innerHeight / 2){
+                window.scrollTo(0, itemNode.offsetTop - (window.innerHeight / 2));
+            }
+        }
+        else {
+            $('.empty-worksheet').fadeIn('fast');
         }
     },
     componentWillUnmount: function(){
@@ -162,7 +165,6 @@ var Worksheet = React.createClass({
             var itemID = 'item' + index;
             return <WorksheetItemFactory item={item} focused={focused} ref={itemID} editing={editing} key={index} onExitEdit={onExitEdit} />;
         });
-        var worksheetItems = listBundles.length ? listBundles : <em>This worksheet is empty!</em>;
         // listBundles is now a list of react components that each el is
         return (
             <div id="worksheet-content" className={keyboardShortcutsClass}>
@@ -181,7 +183,8 @@ var Worksheet = React.createClass({
                         */
                     }
                 </div>
-                <div className="worksheet-items">{worksheetItems}</div>
+                <div className="worksheet-items">{listBundles}</div>
+                <p className="empty-worksheet hidden"><em>This worksheet is empty</em></p>
             </div>
         );
     },

--- a/codalab/apps/web/static/js/worksheet/ws_mixins.js
+++ b/codalab/apps/web/static/js/worksheet/ws_mixins.js
@@ -1,0 +1,73 @@
+/** @jsx React.DOM */
+
+var TableMixin = { 
+    // This handles some common elements of worksheet items that are presented as tables
+    // TableBundle and RecordBundle
+    getInitialState: function(){
+        var state = this.props.item.state;
+        state.rowFocusIndex = 0;
+        state.handleKeyboardShortcuts = this.handleKeyboardShortcuts;
+        return state;
+    },
+    handleKeyboardShortcuts: function(event){
+        var key = keyMap[event.keyCode];
+        var index = this.state.rowFocusIndex;
+        var rowsInTable = this.props.item.state.interpreted[1].length;
+        if(typeof key !== 'undefined'){
+            event.preventDefault();
+            switch (key) {
+                case 'up':
+                case 'k':
+                    event.preventDefault();
+                    index = Math.max(this.state.rowFocusIndex - 1, 0);
+                    if(this.state.rowFocusIndex == 0){
+                        ws_interactions.state.worksheetFocusIndex--;
+                        ws_broker.fire('updateState');
+                    }else {
+                        this.setState({rowFocusIndex: index});
+                    }
+                    break;
+                case 'down':
+                case 'j':
+                    event.preventDefault();
+                    index = Math.min(this.state.rowFocusIndex + 1, rowsInTable);
+                    if(index == rowsInTable){
+                        ws_interactions.state.worksheetFocusIndex++;
+                        ws_broker.fire('updateState');
+                    }else {
+                        this.setState({rowFocusIndex: index});
+                    }
+                    break;
+                case 'd':
+                    if(event.ctrlKey || event.metaKey){
+                        this._owner._owner.deleteItem(ws_interactions.state.worksheetFocusIndex)
+                    }else {
+                        this.deleteRow(this.state.rowFocusIndex);
+                    }
+                    break;
+                default:
+                    return true;
+                }
+            } else {
+                return true;
+            }
+        event.stopPropagation();
+    },
+    deleteRow: function(index){
+        var newItems = this.state.interpreted[1];
+        if(index == newItems.length - 1){
+            if(newItems.length == 1){
+                // delete the whole table by calling its grandparent
+                this._owner._owner.deleteItem(ws_interactions.state.worksheetFocusIndex);
+            }else{
+                // it's the last row, so change the focus to the new last row
+                this.setState({rowFocusIndex:index-1});
+            }
+        }
+        newItems.splice(index, 1);
+        this.setState({interpreted:[
+            this.state.interpreted[0],
+            newItems
+        ]});
+    }
+}

--- a/codalab/apps/web/templates/web/worksheets/detail.html
+++ b/codalab/apps/web/templates/web/worksheets/detail.html
@@ -42,6 +42,7 @@
     <script src="{{ STATIC_URL }}js/worksheet/worksheet_interactions.js"></script>
     {#  JSX FILES #}
     <script type="text/jsx" src="{{ STATIC_URL }}js/search/general_search.js"></script>
+    <script type="text/jsx" src="{{ STATIC_URL }}js/worksheet/ws_mixins.js"></script>
     <script type="text/jsx" src="{{ STATIC_URL }}js/worksheet/worksheet_interface.js"></script>
     <script type="text/jsx" src="{{ STATIC_URL }}js/worksheet/inline_bundle_interface.js"></script>
     <script type="text/jsx" src="{{ STATIC_URL }}js/worksheet/table_bundle_interface.js"></script>


### PR DESCRIPTION
Press (d) to delete the focused worksheet item. If the focused worksheet item is rendered as a table ("table" or "record" modes) d will delete the focused row and ctrl+d or cmd+d will delete the whole table.
