### PR TITLE
#665 keyboard nav fixes

### DIFF
--- a/codalab/apps/web/static/css/worksheets.css
+++ b/codalab/apps/web/static/css/worksheets.css
@@ -77,6 +77,10 @@
   padding:0.5em;
   width:100%;
 }
+#worksheet_content .type-markup,
+#worksheet_content .type-inline {
+  min-height:1.5em;
+}
 #worksheet_content .type-markup ul,
 #worksheet_content .type-markup ol {
   margin: 0 0 1em 0;

--- a/codalab/apps/web/static/js/worksheet/inline_bundle_interface.js
+++ b/codalab/apps/web/static/js/worksheet/inline_bundle_interface.js
@@ -10,14 +10,16 @@ var InlineBundle = React.createClass({
         this.props.setFocus(this);
     },
     render: function() {
-        var className = this.props.focused ? 'focused' : '';
+        var className = 'type-inline' + (this.props.focused ? ' focused' : '');
         var checkbox = this.props.canEdit ? <input type="checkbox" className="ws-checkbox" onChange={this.handleCheck} checked={this.state.checked} /> : null;
         return(
             <div className="ws-item" onClick={this.handleClick}>
                 {checkbox}
-                <em className={className}>
-                    {this.state.interpreted}
-                </em>
+                <div className={className}>
+                    <em>
+                        {this.state.interpreted}
+                    </em>
+                </div>
             </div>
         );
     } // end of render function

--- a/codalab/apps/web/static/js/worksheet/worksheet_interface.js
+++ b/codalab/apps/web/static/js/worksheet/worksheet_interface.js
@@ -165,7 +165,7 @@ var WorksheetItemList = React.createClass({
                 case 'down':
                 case 'j':
                     event.preventDefault();
-                    fIndex = Math.min(this.state.focusIndex + 1, this.state.worksheet.items.length - 1);
+                    fIndex = Math.min(this.state.focusIndex + 1, document.querySelectorAll('#worksheet_content .ws-item').length - 1);
                     this.setState({focusIndex: fIndex});
                     this.scrollToItem(fIndex);
                     break;


### PR DESCRIPTION
- set a min-height on inline and markdown bundles so their focused state is apparent even if they're empty
- use the number of rendered .ws-item divs to set the max focus index in case something changed during render()
  #665 
