### PR TITLE
fixes phase view so it works if no active_phase is found

### DIFF
--- a/codalab/apps/web/templates/web/competitions/view.html
+++ b/codalab/apps/web/templates/web/competitions/view.html
@@ -34,7 +34,7 @@
                             <div class="challStatusStripLevel">
                             </div>
                             <section class="challStatusStripSection">
-                                {% if previous_phase %}
+                                {% if previous_phase and active_phase %}
                                 <section>
                                     <h4>Previous</h4>
                                     <span class="phaseLabel phase-label-{{ previous_phase.color }}">{{previous_phase.label}}</span>
@@ -49,6 +49,16 @@
                                     <span class="phaseLabel phase-label-{{ active_phase.color }}">{{active_phase.label}}</span>
                                     <br>
                                     <span>{{active_phase.start_date|utc}} UTC</span>
+                                </section>
+                                {% endif %}
+
+                                {# If we haven't begun the competition yet, show the first phase #}
+                                {% if not active_phase %}
+                                <section>
+                                <h4>First phase</h4>
+                                <span class="phaseLabel phase-label-{{ first_phase.color }}">{{first_phase.label}}</span>
+                                <br>
+                                <span>{{first_phase.start_date|utc}} UTC</span>
                                 </section>
                                 {% endif %}
 

--- a/codalab/apps/web/views.py
+++ b/codalab/apps/web/views.py
@@ -301,10 +301,16 @@ class CompetitionDetailView(DetailView):
 
                 context["previous_phase"] = None
                 context["next_phase"] = None
+                context["first_phase"] = None
 
                 phase_iterator = iter(competition.phases.all())
                 for phase in phase_iterator:
                     submissions[phase] = models.CompetitionSubmission.objects.filter(participant=context['my_participant'], phase=phase)
+
+                    if context["first_phase"] is None:
+                        # Set the first phase if it hasn't been saved yet
+                        context["first_phase"] = phase
+
                     if phase.is_active:
                         context['active_phase'] = phase
                         context['my_active_phase_submissions'] = submissions[phase]


### PR DESCRIPTION
Resolves #686 
## Functional Review

Go to a competition with no phases active, it should only show the "First Phase" instead of the busted view.
