### PR TITLE
updated footer bar links to point to wiki topics.

### DIFF
--- a/codalab/apps/web/templates/base.html
+++ b/codalab/apps/web/templates/base.html
@@ -166,11 +166,11 @@
         <div class="small-6 columns">
             <ul class="inline-list right">
                 <!-- <li>CodaLab v.0 ()</li> -->
-                <li><a href="http://codalab.github.io/codalab/about.html" target="_self">About</a></li>
-                <li><a href="http://codalab.github.io/codalab/forum.html" target="_self">Forum</a></li>
+                <li><a href="https://github.com/codalab/codalab/wiki/Project_About_CodaLab" target="_blank">About</a></li>
+                <li><a href="https://groups.google.com/forum/#!forum/codalabdev" target="_blank">Forum</a></li>
                 <li><a href="http://go.microsoft.com/?linkid=9837806" target="_blank">Survey</a></li>
-                <li><a href="http://codalab.github.io/codalab/notices.html" target="_self">Privacy</a></li>
-                <li><a href="http://codalab.github.io/codalab/terms.html" target="_self">Terms of Use</a></li>
+                <li><a href="https://github.com/codalab/codalab/wiki/Project_Privacy_Policy" target="_blank">Privacy</a></li>
+                <li><a href="https://github.com/codalab/codalab/wiki/Project_Terms_and_Conditions" target="_blank">Terms of Use</a></li>
             </ul>
         </div>
     </footer>


### PR DESCRIPTION
This completes the move away from IO pages. IO pages still exist, but users will never see them, as all navigation has been updated to point to wiki topics. Links to the Google Groups forum are now direct (no more embedded HTML).
