### PR TITLE
Automatically go to the active phase in the Participate and Results tabs

### DIFF
--- a/codalab/apps/web/static/less/competitions.less
+++ b/codalab/apps/web/static/less/competitions.less
@@ -37,7 +37,7 @@
                     color:@blue;
                     span.glyphicon {
                         font-size:16px;
-                        margin-left:-16px;
+                        margin-right:-2px;
                     }
                 }
             }

--- a/codalab/apps/web/templates/web/competitions/_submit_results_page.html
+++ b/codalab/apps/web/templates/web/competitions/_submit_results_page.html
@@ -20,7 +20,7 @@
         {% else %}
             <p>None</p>
         {% endif %}
-    </div>div>
+    </div>
 
     {% if phase.is_active %}
         <div class="form-group">

--- a/codalab/apps/web/templates/web/competitions/view.html
+++ b/codalab/apps/web/templates/web/competitions/view.html
@@ -176,6 +176,17 @@
             $('#competition_tab_nav a, .innertabs a').on('show.bs.tab', function(e){
                 return location.hash = $(e.target).attr('href').substr(1);
             });
+            if($('#participate-submit_results').hasClass('active')){
+                $('#submissions_phase_buttons .active').click();
+            } else if($('#results').hasClass('active')){
+                $('#results_phase_buttons .active').click();
+            };
+            $('a[href="#participate-submit_results"]').on('shown.bs.tab', function(e){
+                $($(e.target).attr('href') + ' .active').click();
+            });
+            $('a[href="#results"]').on('shown.bs.tab', function(e){
+                $($(e.target).attr('href') + ' .active').click();
+            });
         });
     </script>
 {% endblock %}


### PR DESCRIPTION
Also fix alignment of arrow icon indicating current Phase, and remove a stray closing div
