### PR TITLE
Added PIP requirements for OS X

### DIFF
--- a/codalab/requirements/dev_osx.txt
+++ b/codalab/requirements/dev_osx.txt
@@ -1,0 +1,8 @@
+-r common.txt
+supervisor==3.0
+uWSGI==2.0.11.2
+pycrypto==2.6
+MySQL-python
+# Use sckoo@stanford.edu's patched argcomplete, until pull request has been accepted
+# https://github.com/kislyuk/argcomplete/pull/118
+git+https://github.com/kashizui/argcomplete.git@allow-overridden-subparsersaction


### PR DESCRIPTION
There's a bug in the old version of uwsgi that prevents building on
OS X 10.11, see https://github.com/unbit/uwsgi/issues/1056. Fix is to have a
requirements file with an updated version for OS X.