### PR TITLE
Fixes #1674: Better link target for + button

### DIFF
--- a/codalab/apps/web/templates/web/my/submissions.html
+++ b/codalab/apps/web/templates/web/my/submissions.html
@@ -86,7 +86,7 @@
                                 <td>{{submission|get_item:column.name}}</td>
                             {% endif %}
                         {% endfor %}
-                        <td align="center"><a href="#{{submission.id}}" onclick="Competition.showOrHideSubmissionDetails(this)"><span class="glyphicon glyphicon-plus"></span></a></td>
+                        <td align="center"><a href="#{{ submission.id }}" onclick="Competition.showOrHideSubmissionDetails(this)"><span class="glyphicon glyphicon-plus"></span></a></td>
                         <td align="center"><a class="btn btn-danger btn-xs" href="{% url "competitions:submission_delete" pk=submission.id %}">DEL</a></td>
                         <td align="center">
                             <button class="btn btn-danger btn-xs hide_or_show_submission_button">

--- a/codalab/apps/web/templates/web/my/submissions.html
+++ b/codalab/apps/web/templates/web/my/submissions.html
@@ -86,7 +86,7 @@
                                 <td>{{submission|get_item:column.name}}</td>
                             {% endif %}
                         {% endfor %}
-                        <td align="center"><a href="#" onclick="Competition.showOrHideSubmissionDetails(this)"><span class="glyphicon glyphicon-plus"></span></a></td>
+                        <td align="center"><a href="#{{submission.id}}" onclick="Competition.showOrHideSubmissionDetails(this)"><span class="glyphicon glyphicon-plus"></span></a></td>
                         <td align="center"><a class="btn btn-danger btn-xs" href="{% url "competitions:submission_delete" pk=submission.id %}">DEL</a></td>
                         <td align="center">
                             <button class="btn btn-danger btn-xs hide_or_show_submission_button">


### PR DESCRIPTION
Untested (but fairly obvious) fix for Issue #1674.  Made the link target for the + button the enclosing `tr` element.