### PR TITLE
CSV download for admins/creator

### DIFF
--- a/codalab/apps/web/views.py
+++ b/codalab/apps/web/views.py
@@ -673,8 +673,7 @@ class CompetitionCompleteResultsDownload(View):
     def get(self, request, *args, **kwargs):
         competition = models.Competition.objects.get(pk=self.kwargs['id'])
         phase = competition.phases.get(pk=self.kwargs['phase'])
-        if phase.is_blind:
-            return HttpResponse(status=403)
+
         groups = phase.scores(include_scores_not_on_leaderboard=True)
         leader_board = models.PhaseLeaderBoard.objects.get(phase=phase)
 


### PR DESCRIPTION
fixes #1676 

## Short summary 

- Since Submissions view is only accessible by admin/creators, they should be able to Download CSV files. This is a behavior we already have in other places. 