### PR TITLE
Makes watch a dev dependency

### DIFF
--- a/codalab/package.json
+++ b/codalab/package.json
@@ -10,7 +10,9 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "less": "^2.7.2",
+    "less": "^2.7.2"
+  },
+  "devDependencies": {
     "watch": "^1.0.2"
-  }
+ }
 }


### PR DESCRIPTION
This changes package.json so that watch is a dev dependency, since that feature's not necessary for building in production.   still get to watch by running `npm run watch-css`
