### PR TITLE
Updates progress bar styling

### DIFF
--- a/codalab/apps/web/static/less/my.less
+++ b/codalab/apps/web/static/less/my.less
@@ -81,6 +81,12 @@
     display: none !important;
 }
 
-.s3direct .progress {
+#s3-file-upload.btn {
+    width: 100%;
+}
+
+.s3direct {
+  .progress {
     display: none !important;
+  }
 }

--- a/codalab/apps/web/static/less/my.less
+++ b/codalab/apps/web/static/less/my.less
@@ -77,6 +77,10 @@
 /***********************
  * SUBMIT RESULTS PAGE *
  ***********************/
-.s3direct.form-active, .s3direct.link-active {
+.s3direct.form-active, .s3direct.link-active, .submission_upload_details {
+    display: none !important;
+}
+
+.s3direct .progress {
     display: none !important;
 }

--- a/codalab/apps/web/templates/web/competitions/_submit_results_page.html
+++ b/codalab/apps/web/templates/web/competitions/_submit_results_page.html
@@ -50,7 +50,7 @@
                 {{ form }}
                 <div id="s3-file-upload"
                         class="button btn btn-primary {% if not phase.reference_data %}disabled{% endif %}"
-                        {% if not phase.reference_data %}disabled="disabled"{% endif %}>
+                        {% if not phase.reference_data %}disabled="disabled"{% endif %} style="width:100%;">
                     Submit
                 </div>
             </form>
@@ -151,5 +151,3 @@
         test_if_done()
     });
 </script>
-
-

--- a/codalab/apps/web/templates/web/competitions/_submit_results_page.html
+++ b/codalab/apps/web/templates/web/competitions/_submit_results_page.html
@@ -50,7 +50,7 @@
                 {{ form }}
                 <div id="s3-file-upload"
                         class="button btn btn-primary {% if not phase.reference_data %}disabled{% endif %}"
-                        {% if not phase.reference_data %}disabled="disabled"{% endif %} style="width:100%;">
+                        {% if not phase.reference_data %}disabled="disabled"{% endif %}>
                     Submit
                 </div>
             </form>


### PR DESCRIPTION
Clicking submit button now only shows the project added to the chart below.  This commit hides animations from progress bar etc.

![screen shot 2017-03-09 at 1 45 24 pm](https://cloud.githubusercontent.com/assets/13974084/23765278/af67495c-04ce-11e7-9979-8b4bff38284a.png)
