### PR TITLE
Issue 1788: Creates links back to competition homepages.

### DIFF
--- a/codalab/apps/teams/templates/teams/team_info.html
+++ b/codalab/apps/teams/templates/teams/team_info.html
@@ -12,6 +12,8 @@
     <link rel="stylesheet" href="{{ STATIC_URL }}teams/teams.css">
 {% endblock %}
 {% block content %}
+    <a href="{% url "competitions:view" pk=competition.pk %}" class="pull-right" >Go Back to Competition Homepage</a>
+
     <div class="container-fluid">
         <div class="row">
             <div class="col-lg-12">
@@ -19,9 +21,8 @@
             </div>
         </div>
     </div>
-    <a href="{% url "competitions:view" pk=competition.pk%}" class="pull-right" >Go Back to Competition Homepage</a>
 
-    <br>
+
     <div class="teams">
         <div class="">
             {% if not team %}

--- a/codalab/apps/web/templates/web/competitions/edit.html
+++ b/codalab/apps/web/templates/web/competitions/edit.html
@@ -14,8 +14,8 @@
 
 {% block content %}
 <div class='container-fluid'>
-<a href="{% url "competitions:view" pk=competition.pk %}" >Go Back to Competition Homepage</a>
-<a class="pull-right" href="https://github.com/codalab/codalab/wiki/User_Competition-Roadmap" title="Get help with creating a competition" target="_blank"><span class="glyphicon glyphicon-question-sign"></span> Help</a>
+    <a href="{% url "competitions:view" pk=competition.pk %}" >Go Back to Competition Homepage</a>
+    <a class="pull-right" href="https://github.com/codalab/codalab/wiki/User_Competition-Roadmap" title="Get help with creating a competition" target="_blank"><span class="glyphicon glyphicon-question-sign"></span> Help</a>
 </div>
 <a class="btn btn-secondary" href="{% url 'competitions:download_yaml' competition_pk=competition.pk %}">Download original YAML file</a>
 <form id="competition_edit_form" class="form-horizontal form-controller margin-top" data-abide enctype="multipart/form-data" method="POST">{% csrf_token %}

--- a/codalab/apps/web/templates/web/competitions/edit.html
+++ b/codalab/apps/web/templates/web/competitions/edit.html
@@ -13,12 +13,10 @@
 {% endblock extra_scripts %}
 
 {% block content %}
-
-<a href="{% url "competitions:view" pk=competition.pk %}" class="pull-right" >Go Back to Competition Homepage</a>
-
-<br>
-
+<div class='container-fluid'>
+<a href="{% url "competitions:view" pk=competition.pk %}" >Go Back to Competition Homepage</a>
 <a class="pull-right" href="https://github.com/codalab/codalab/wiki/User_Competition-Roadmap" title="Get help with creating a competition" target="_blank"><span class="glyphicon glyphicon-question-sign"></span> Help</a>
+</div>
 <a class="btn btn-secondary" href="{% url 'competitions:download_yaml' competition_pk=competition.pk %}">Download original YAML file</a>
 <form id="competition_edit_form" class="form-horizontal form-controller margin-top" data-abide enctype="multipart/form-data" method="POST">{% csrf_token %}
     <fieldset>

--- a/codalab/apps/web/templates/web/my/participants.html
+++ b/codalab/apps/web/templates/web/my/participants.html
@@ -12,7 +12,7 @@
 
 {% block content %}
 
-<a href="{% url "competitions:view" pk=competition_id%}" class="pull-right" >Go Back to Competition Homepage</a>
+<a href="{% url "competitions:view" pk=competition_id %}" class="pull-right" >Go Back to Competition Homepage</a>
 
 <div class="participants">
     <h3>Teams</h3>


### PR DESCRIPTION
https://github.com/codalab/codalab-competitions/commit/7b437bceba772d16dbc3a709f634fdda169764f3

Creates a separate branch for links back to competition homepage, separate from  charts-js.