### PR TITLE
1795 top3leader

### DIFF
--- a/codalab/apps/queues/views.py
+++ b/codalab/apps/queues/views.py
@@ -45,7 +45,6 @@ class QueueCreateView(LoginRequiredMixin, QueueFormMixin, CreateView):
 
             # Only save queue if things were successful
             queue.save()
-            form.save_m2m()
             return HttpResponseRedirect(self.get_success_url())
         except HTTPError:
             errors = form._errors.setdefault("__all__", ErrorList())

--- a/codalab/apps/web/models.py
+++ b/codalab/apps/web/models.py
@@ -1550,8 +1550,7 @@ class CompetitionDefBundle(models.Model):
                 comp.save()
                 logger.debug("CompetitionDefBundle::unpack saved competition logo (pk=%s)", self.pk)
             except KeyError:
-                assert False, "Could not find file in archive, make sure scoring_program, reference_data and logo are " \
-                              "set to correct file paths."
+                assert False, "Could not find image {} in archive.".format(comp_base['image'])
 
         # Populate competition pages
         pc,_ = PageContainer.objects.get_or_create(object_id=comp.id, content_type=ContentType.objects.get_for_model(comp))

--- a/codalab/apps/web/models.py
+++ b/codalab/apps/web/models.py
@@ -498,7 +498,7 @@ class Competition(models.Model):
     def get_participant_count(self):
         return self.participants.all().count()
 
-    def get_topthree(self):
+    def get_top_three(self):
         """
         Returns top 3 in the leaderboard
         """
@@ -530,14 +530,14 @@ class Competition(models.Model):
                     scoredata['date'] = sub.submitted_at
                     scoredata['count'] = sub.phase.submissions.filter(participant=sub.participant).count()
 
-            top_threelist= []
+            top_three = []
 
             if len(local_scores) > 0 and len(local_scores[0]) > 0 and len(local_scores[0]['scores']) > 0:
 
                 num_part = len(local_scores[0]['scores'])
                 local_scores = local_scores[0]['scores']
 
-                if num_part > 3: ## Keep us in 1-3 range.
+                if num_part > 3: # Keep us in 1-3 range.
                     num_part = 3
 
                 for index in range(num_part):
@@ -547,9 +547,9 @@ class Competition(models.Model):
                         'score': local_scores[index][1]['values'][0]['val']
                     }   
 
-                    top_threelist.append(temp_dict.copy())
+                    top_three.append(temp_dict.copy())
 
-            return top_threelist ## Return only our top 3, with the data we want.
+            return top_three # Return only our top 3, with the data we want.
 
 post_save.connect(Forum.competition_post_save, sender=Competition)
 

--- a/codalab/apps/web/models.py
+++ b/codalab/apps/web/models.py
@@ -1498,7 +1498,8 @@ class CompetitionDefBundle(models.Model):
                 comp.save()
                 logger.debug("CompetitionDefBundle::unpack saved competition logo (pk=%s)", self.pk)
             except KeyError:
-                assert False, "Could not find image {} in archive.".format(comp_base['image'])
+                assert False, "Could not find file in archive, make sure scoring_program, reference_data and logo are " \
+                              "set to correct file paths."
 
         # Populate competition pages
         pc,_ = PageContainer.objects.get_or_create(object_id=comp.id, content_type=ContentType.objects.get_for_model(comp))

--- a/codalab/apps/web/models.py
+++ b/codalab/apps/web/models.py
@@ -532,20 +532,22 @@ class Competition(models.Model):
 
             top_threelist= []
 
-            num_part = len(local_scores[0]['scores'])
-            local_scores = local_scores[0]['scores']
+            if len(local_scores) > 0 and len(local_scores[0]) > 0 and len(local_scores[0]['scores']) > 0:
 
-            if num_part > 3: ## Keep us in 1-3 range.
-                num_part = 3
+                num_part = len(local_scores[0]['scores'])
+                local_scores = local_scores[0]['scores']
 
-            for index in range(num_part):
+                if num_part > 3: ## Keep us in 1-3 range.
+                    num_part = 3
 
-                temp_dict = {
-                    'username': local_scores[index][1]['username'],
-                    'score': local_scores[index][1]['values'][0]['val']
-                }
+                for index in range(num_part):
 
-                top_threelist.append(temp_dict.copy())
+                    temp_dict = {
+                        'username': local_scores[index][1]['username'],
+                        'score': local_scores[index][1]['values'][0]['val']
+                    }   
+
+                    top_threelist.append(temp_dict.copy())
 
             return top_threelist ## Return only our top 3, with the data we want.
 

--- a/codalab/apps/web/templates/web/competitions/_chart.html
+++ b/codalab/apps/web/templates/web/competitions/_chart.html
@@ -1,6 +1,6 @@
 {% load codalab_tags %}
 
-<canvas id="chart" width="400" height="200"></canvas>
+<canvas id="chart" width="400" height="150"></canvas>
 <script>
     var ctx = document.getElementById("chart");
     var local_highscore = 0
@@ -15,7 +15,7 @@
                     yAxisID: 'score',
                     data: [{% for high_score in graph.high_scores %}{{ high_score|floatformat }}, {% endfor %}],
                     borderColor: 'rgba(255, 99, 132, 1)',
-                    backgroundColor: 'rgba(255, 99, 132, 0.5)'
+                    //backgroundColor: 'rgba(255, 99, 132, 0.5)' This controls shaded areas under line.
                 },
                 {
                     type: 'bar',

--- a/codalab/apps/web/templates/web/competitions/_results_page.html
+++ b/codalab/apps/web/templates/web/competitions/_results_page.html
@@ -81,13 +81,26 @@
                     {% for pk, scoredata in group.scores %}
                         <tr {% if phase.competition.anonymous_leaderboard and request.user.username == scoredata.username %}style="background-color: #D7FFFA;"{% endif %}>
                             <td class="row-position">
-                                {{ forloop.counter }}
+                                {% if forloop.counter < 4 %}
+                                    <b><p style="color:green;">{{ forloop.counter }}</p></b>
+                                {% else %}
+                                    {{ forloop.counter }}
+                                {% endif %}
                             </td>
                             <td>
                                 {% if phase.competition.anonymous_leaderboard %}
-                                    <i>Anonymous</i>
+                                    {% if forloop.counter < 4 %}
+                                        <b><p style="color:green;"><i>Anonymous</i></p></b>
+                                    {% else %}
+                                        <i>Anonymous</i>
+                                    {% endif %} 
+                                    
                                 {% else %}
-                                    {{ scoredata.username }}
+                                    {% if forloop.counter < 4 %}
+                                        <b><p style="color:green;">{{ scoredata.username }}</p></b>
+                                    {% else %}
+                                        {{ scoredata.username }}
+                                    {% endif %}  
                                 {% endif %}
                             </td>
                             <td> {{ scoredata.count }} </td>

--- a/codalab/apps/web/templates/web/competitions/view.html
+++ b/codalab/apps/web/templates/web/competitions/view.html
@@ -229,29 +229,58 @@
             {% endfor %}
         </div>
     </section>
-
-    {% if topthreeleaders %}
-        <div class="panel-body" style="border: 1px solid grey;">
-            <center><h4>Top Three Competitors in: {{ competition.title }}</h4></center>
-            <div class="table table-bordered">
-                <table width="100%">
-                    <tr style="border: 1px solid black;">
-                        <th>Rank</th>
-                        <th>Username</th>
-                        <th>Score</th>            
-                    </tr>
-                    {% for leader in topthreeleaders %}
-                        <tr>
-                            <td>{{ forloop.counter }}</td>
-                            <td>{{ leader.username }}</td>
-                            <td>{{ leader.score }}</td>
-                        </tr>
-                    {% endfor %}
-                </table>
-            </div>
+    <div class="row">
+        <div class="col-md-4">
+            {% if topthreeleaders %}
+                <div class="panel">
+                    <div class="panel-body"">
+                        <center><h4>Top Three</h4></center>
+                        <table class="table table-responsive">
+                            <thead>
+                                <tr>
+                                    <th>Rank</th>
+                                    <th>Username</th>
+                                    <th>Score</th>            
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for leader in topthreeleaders %}
+                                    <tr>
+                                        <td>{{ forloop.counter }}</td>
+                                        <td>{{ leader.username }}</td>
+                                        <td>{{ leader.score }}</td>
+                                    </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            {% else %}
+                <div class="panel">
+                    <div class="panel-body"">
+                        <center><h4>Top Three</h4></center>
+                        <table class="table table-responsive">
+                            <thead>
+                                <tr>
+                                    <th>Rank</th>
+                                    <th>Username</th>
+                                    <th>Score</th>            
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>No data</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            {% endif %}
         </div>
-    {% endif %}
-
+        <div class="col-md-8">
+            {% include "web/competitions/_chart.html" %}
+        </div>
+    </div>
 </div>
 
 {% endblock content %}

--- a/codalab/apps/web/templates/web/competitions/view.html
+++ b/codalab/apps/web/templates/web/competitions/view.html
@@ -230,25 +230,27 @@
         </div>
     </section>
 
-    <div class="phase-container" style="border: 1px solid grey;">
-        <center><h4>Top Three Competitors in: {{competition.title}}</h4></center>
-        <div class="leaderboard-result-table">
-            <table width="100%">
-                <tr style="border: 1px solid black;">
-                    <th>Rank</th>
-                    <th>Username</th>
-                    <th>Score</th>            
-                </tr>
-                {% for leader in topthreeleaders %}
-                    <tr>
-                        <td>{{forloop.counter}}</td>
-                        <td>{{leader.username}}</td>
-                        <td>{{leader.score}}</td>
+    {% if topthreeleaders %}
+        <div class="phase-container" style="border: 1px solid grey;">
+            <center><h4>Top Three Competitors in: {{competition.title}}</h4></center>
+            <div class="leaderboard-result-table">
+                <table width="100%">
+                    <tr style="border: 1px solid black;">
+                        <th>Rank</th>
+                        <th>Username</th>
+                        <th>Score</th>            
                     </tr>
-                {% endfor %}
-            </table>
+                    {% for leader in topthreeleaders %}
+                        <tr>
+                            <td>{{forloop.counter}}</td>
+                            <td>{{leader.username}}</td>
+                            <td>{{leader.score}}</td>
+                        </tr>
+                    {% endfor %}
+                </table>
+            </div>
         </div>
-    </div>
+    {% endif %}
 
 </div>
 

--- a/codalab/apps/web/templates/web/competitions/view.html
+++ b/codalab/apps/web/templates/web/competitions/view.html
@@ -229,6 +229,27 @@
             {% endfor %}
         </div>
     </section>
+
+    <div class="phase-container" style="border: 1px solid grey;">
+        <center><h4>Top Three Competitors in: {{competition.title}}</h4></center>
+        <div class="leaderboard-result-table">
+            <table width="100%">
+                <tr style="border: 1px solid black;">
+                    <th>Rank</th>
+                    <th>Username</th>
+                    <th>Score</th>            
+                </tr>
+                {% for leader in topthreeleaders %}
+                    <tr>
+                        <td>{{forloop.counter}}</td>
+                        <td>{{leader.username}}</td>
+                        <td>{{leader.score}}</td>
+                    </tr>
+                {% endfor %}
+            </table>
+        </div>
+    </div>
+
 </div>
 
 {% endblock content %}

--- a/codalab/apps/web/templates/web/competitions/view.html
+++ b/codalab/apps/web/templates/web/competitions/view.html
@@ -231,9 +231,9 @@
     </section>
 
     {% if topthreeleaders %}
-        <div class="phase-container" style="border: 1px solid grey;">
-            <center><h4>Top Three Competitors in: {{competition.title}}</h4></center>
-            <div class="leaderboard-result-table">
+        <div class="panel-body" style="border: 1px solid grey;">
+            <center><h4>Top Three Competitors in: {{ competition.title }}</h4></center>
+            <div class="table table-bordered">
                 <table width="100%">
                     <tr style="border: 1px solid black;">
                         <th>Rank</th>
@@ -242,9 +242,9 @@
                     </tr>
                     {% for leader in topthreeleaders %}
                         <tr>
-                            <td>{{forloop.counter}}</td>
-                            <td>{{leader.username}}</td>
-                            <td>{{leader.score}}</td>
+                            <td>{{ forloop.counter }}</td>
+                            <td>{{ leader.username }}</td>
+                            <td>{{ leader.score }}</td>
                         </tr>
                     {% endfor %}
                 </table>

--- a/codalab/apps/web/views.py
+++ b/codalab/apps/web/views.py
@@ -485,11 +485,11 @@ class CompetitionDetailView(DetailView):
         context['site'] = Site.objects.get_current()
         context['current_server_time'] = datetime.now()
 
-        ## Top 3 Leaderboard
+        # Top 3 Leaderboard
 
         my_leaders = []
 
-        my_leaders = self.get_object().get_topthree()
+        my_leaders = self.get_object().get_top_three()
 
         context['topthreeleaders'] = my_leaders
 

--- a/codalab/apps/web/views.py
+++ b/codalab/apps/web/views.py
@@ -485,6 +485,14 @@ class CompetitionDetailView(DetailView):
         context['site'] = Site.objects.get_current()
         context['current_server_time'] = datetime.now()
 
+        ## Top 3 Leaderboard
+
+        my_leaders = []
+
+        my_leaders = self.get_object().get_topthree()
+
+        context['topthreeleaders'] = my_leaders
+
         if settings.USE_AWS:
             context['submission_upload_form'] = forms.SubmissionS3UploadForm
 

--- a/codalab/apps/web/views.py
+++ b/codalab/apps/web/views.py
@@ -486,12 +486,27 @@ class CompetitionDetailView(DetailView):
         context['current_server_time'] = datetime.now()
 
         # Top 3 Leaderboard
-
+        # Get the month from submitted_at
+        truncate_date = connection.ops.date_trunc_sql('day', 'submitted_at')
+        score_def = SubmissionScoreDef.objects.get(competition=competition, ordering=1)
+        qs = SubmissionScore.objects.filter(result__phase__competition=competition, scoredef__ordering=1)
+        qs = qs.extra({'day': truncate_date}).values('day')
+        if score_def.sorting == 'asc':
+            best_value = Max('value')
+        else:
+            best_value = Min('value')
+        qs = qs.annotate(high_score=best_value, count=Count('pk'))
+        context['graph'] = {
+            'days': [s['day'].strftime('%d %B %Y')  # ex 24 May 2017
+                       for s in qs],
+            'high_scores': [s['high_score'] for s in qs],
+            'counts': [s['count'] for s in qs],
+            'sorting': score_def.sorting,
+        }
         my_leaders = []
-
         my_leaders = self.get_object().get_top_three()
-
         context['topthreeleaders'] = my_leaders
+        # End top 3 leaderboard
 
         if settings.USE_AWS:
             context['submission_upload_form'] = forms.SubmissionS3UploadForm


### PR DESCRIPTION
![top_3_leaderboard_](https://cloud.githubusercontent.com/assets/28552312/26473623/66af7214-4161-11e7-894a-d7654ccf9490.gif)

- Adds a top 3 leaderboard to the bottom of each competition detail view as a separate container.
- Styles top 3 in results with green.
