### PR TITLE
Fixes clearing organizers when editing queue

### DIFF
--- a/codalab/apps/queues/views.py
+++ b/codalab/apps/queues/views.py
@@ -45,6 +45,7 @@ class QueueCreateView(LoginRequiredMixin, QueueFormMixin, CreateView):
 
             # Only save queue if things were successful
             queue.save()
+            form.save_m2m()
             return HttpResponseRedirect(self.get_success_url())
         except HTTPError:
             errors = form._errors.setdefault("__all__", ErrorList())


### PR DESCRIPTION
Adds line `form.save_m2m()` to call saving many to many relationship fields in form after instantiating a queue object. 

Fixes: 

#1792 

![woker_no_clear_org](https://cloud.githubusercontent.com/assets/28552312/26516786/f67bf86a-4240-11e7-9682-ccdb4d2b568a.gif)

*accidently spammed save while browser was loading page at end of the gif*

