### PR TITLE
Shows score properly on submissions list page

### DIFF
--- a/codalab/apps/web/views.py
+++ b/codalab/apps/web/views.py
@@ -1217,7 +1217,7 @@ class MyCompetitionSubmissionsPage(LoginRequiredMixin, TemplateView):
                 'name': 'is_in_leaderboard'
             },
         ]
-        scores = active_phase.scores()
+        scores = active_phase.scores(include_scores_not_on_leaderboard=True)
         for score_group_index, score_group in enumerate(scores):
             column = {
                 'label': score_group['label'],
@@ -1242,13 +1242,26 @@ class MyCompetitionSubmissionsPage(LoginRequiredMixin, TemplateView):
                 'submission_pk': submission.id,
                 'is_migrated': submission.is_migrated
             }
+            
+            # Removed if to show scores on submissions view.
+
+            #if (submission_info['is_in_leaderboard'] == True):
             # add score groups into data columns
-            if (submission_info['is_in_leaderboard'] == True):
-                for score_group_index, score_group in enumerate(scores):
-                    user_score = filter(lambda user_score: user_score[1]['username'] == submission.participant.user.username, score_group['scores'])[0]
+
+            for score_group_index, score_group in enumerate(scores):
+
+                # Need to figure out a way to check if submission is garbage.
+                try:
+                    user_score = filter(lambda user_score: user_score[1]['id'] == submission.id, score_group['scores'])[0] # This line return error.
                     main_score = filter(lambda main_score: main_score['name'] == score_group['selection_key'], user_score[1]['values'])[0]
                     submission_info['score_' + str(score_group_index)] = main_score['val']
+                # If submission is garbage put in garbage data.
+                except:
+                    user_score = "---"
+                    main_score = "---"
+                    submission_info['score_' + str(score_group_index)] = "---"
             submission_info_list.append(submission_info)
+
         # order results
         sort_data_table(self.request, context, submission_info_list)
         # complete context

--- a/codalab/apps/web/views.py
+++ b/codalab/apps/web/views.py
@@ -1242,14 +1242,11 @@ class MyCompetitionSubmissionsPage(LoginRequiredMixin, TemplateView):
                 'submission_pk': submission.id,
                 'is_migrated': submission.is_migrated
             }
-            
             # Removed if to show scores on submissions view.
 
             #if (submission_info['is_in_leaderboard'] == True):
             # add score groups into data columns
-
             for score_group_index, score_group in enumerate(scores):
-
                 # Need to figure out a way to check if submission is garbage.
                 try:
                     user_score = filter(lambda user_score: user_score[1]['id'] == submission.id, score_group['scores'])[0] # This line return error.
@@ -1261,7 +1258,6 @@ class MyCompetitionSubmissionsPage(LoginRequiredMixin, TemplateView):
                     main_score = "---"
                     submission_info['score_' + str(score_group_index)] = "---"
             submission_info_list.append(submission_info)
-
         # order results
         sort_data_table(self.request, context, submission_info_list)
         # complete context


### PR DESCRIPTION
Fixes Issue: #1766 

All submissions on submission page now show scores regardless if on leader-board or not. Tested on multiple competitions and working after fixing some bugs with the implementation. Failed submissions now show no score as well.

![force_show_score](https://cloud.githubusercontent.com/assets/28552312/26601828/4689b20a-4536-11e7-88c5-95f77661b17b.gif)

*Note: Submission Answers with internal errors were used on purpose for testing, since this originally introduced a bug*