### PR TITLE
1777 mysql to postgres

### DIFF
--- a/codalab/apps/web/migrations/0001_initial.py
+++ b/codalab/apps/web/migrations/0001_initial.py
@@ -7,6 +7,11 @@ from django.db import models
 
 class Migration(SchemaMigration):
 
+    depends_on = (
+        ("queues", "0001_initial"),
+    )
+
+
     def forwards(self, orm):
         pass
 

--- a/codalab/apps/web/migrations/0057_auto__add_field_competitionsubmission_team__add_field_competition_enab.py
+++ b/codalab/apps/web/migrations/0057_auto__add_field_competitionsubmission_team__add_field_competition_enab.py
@@ -7,6 +7,11 @@ from django.db import models
 
 class Migration(SchemaMigration):
 
+    depends_on = (
+        ("teams", "0001_initial"),
+    )
+
+
     def forwards(self, orm):
         # Adding field 'CompetitionSubmission.team'
         db.add_column(u'web_competitionsubmission', 'team',

--- a/codalab/codalab/settings/base.py
+++ b/codalab/codalab/settings/base.py
@@ -522,11 +522,11 @@ class Base(Settings):
                 DATABASES = {
                     'default': {
                         'ENGINE': 'django.db.backends.postgresql_psycopg2',
-				        'NAME': os.environ.get('DB_PG_NAME', 'postgres'),
-				        'USER': os.environ.get('DB_PG_USER', 'postgres'),
-				        'PASSWORD': os.environ.get('DB_PG_PASSWORD', ''),
-				        'HOST': os.environ.get('DB_PG_HOST', 'postgres'),
-				        'PORT': os.environ.get('DB_PG_PORT', '5432'),
+                        'NAME': os.environ.get('DB_NAME', 'codalab_website'),
+                        'USER': os.environ.get('DB_USER', 'postgres'),
+                        'PASSWORD': os.environ.get('DB_PASSWORD', ''),
+                        'HOST': os.environ.get('DB_HOST', 'postgres'),
+                        'PORT': os.environ.get('DB_PORT', '5432'),
                     }
                 }
             elif db_engine == 'sqlite3':

--- a/codalab/codalab/settings/base.py
+++ b/codalab/codalab/settings/base.py
@@ -568,15 +568,6 @@ class Base(Settings):
                     }
                 }
 
-    DATABASES['postgres'] = {
-    	'ENGINE': 'django.db.backends.postgresql_psycopg2',
-        'NAME': os.environ.get('DB_PG_NAME', 'postgres'),
-        'USER': os.environ.get('DB_PG_USER', 'postgres'),
-        'PASSWORD': os.environ.get('DB_PG_PASSWORD', ''),
-        'HOST': os.environ.get('DB_PG_HOST', 'postgres'),
-        'PORT': os.environ.get('DB_PG_PORT', '5432'),
-    }
-
     # =========================================================================
     # Misc
     # =========================================================================

--- a/codalab/codalab/settings/base.py
+++ b/codalab/codalab/settings/base.py
@@ -522,11 +522,11 @@ class Base(Settings):
                 DATABASES = {
                     'default': {
                         'ENGINE': 'django.db.backends.postgresql_psycopg2',
-                        'NAME': os.environ.get('DB_NAME'),
-                        'USER': os.environ.get('DB_USER', 'root'),
-                        'PASSWORD': os.environ.get('DB_PASSWORD'),
-                        'HOST': os.environ.get('DB_HOST', 'postgresql'),
-                        'PORT': os.environ.get('DB_PORT', '5432'),
+				        'NAME': os.environ.get('DB_PG_NAME', 'postgres'),
+				        'USER': os.environ.get('DB_PG_USER', 'postgres'),
+				        'PASSWORD': os.environ.get('DB_PG_PASSWORD', ''),
+				        'HOST': os.environ.get('DB_PG_HOST', 'postgres'),
+				        'PORT': os.environ.get('DB_PG_PORT', '5432'),
                     }
                 }
             elif db_engine == 'sqlite3':
@@ -567,6 +567,15 @@ class Base(Settings):
                         'NAME': 'codalab.sqlite3',
                     }
                 }
+
+    DATABASES['postgres'] = {
+    	'ENGINE': 'django.db.backends.postgresql_psycopg2',
+        'NAME': os.environ.get('DB_PG_NAME', 'postgres'),
+        'USER': os.environ.get('DB_PG_USER', 'postgres'),
+        'PASSWORD': os.environ.get('DB_PG_PASSWORD', ''),
+        'HOST': os.environ.get('DB_PG_HOST', 'postgres'),
+        'PORT': os.environ.get('DB_PG_PORT', '5432'),
+    }
 
     # =========================================================================
     # Misc

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,11 +40,15 @@ services:
 
   postgres:
     image: postgres:9.6.3
+    environment:
+      - POSTGRES_DB=${DB_NAME}
+      - POSTGRES_USER=${DB_USER}
+      - POSTGRES_PASSWORD=${DB_PASSWORD}
     volumes:
       - ./docker:/app/docker
       - ./docker/psql:/etc/psql/conf.d
       - ${LOGGING_DIR}/psql:/var/log/psql
-      - ${DB_PG_DATA_PATH}:/var/lib/psql
+      - ${DB_DATA_PATH}:/var/lib/postgres
     env_file: .env
     container_name: postgres
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,16 @@ services:
     env_file: .env
     container_name: mysql
 
+  postgres:
+    image: postgres:9.6.3
+    volumes:
+      - ./docker:/app/docker
+      - ./docker/psql:/etc/psql/conf.d
+      - ${LOGGING_DIR}/psql:/var/log/psql
+      - ${DB_PG_DATA_PATH}:/var/lib/psql
+    env_file: .env
+    container_name: postgres
+
 
   # --------------------------------------------------------------------------
   # Message queue

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,6 @@ services:
       - POSTGRES_PASSWORD=${DB_PASSWORD}
     volumes:
       - ./docker:/app/docker
-      - ./docker/psql:/etc/psql/conf.d
       - ${LOGGING_DIR}/psql:/var/log/psql
       - ${DB_DATA_PATH}:/var/lib/postgres
     env_file: .env


### PR DESCRIPTION
Sets up branches to use postgres instead of mysql.

Note: The following must be set in .env

```
DB_HOST=postgres
DB_PORT=5432
DB_NAME=codalab_website
DB_USER=root
DB_PASSWORD=password -- Change to your setup.
DB_DATA_PATH=./var/data/postgres

DB_ENGINE = postgresql -- This variable is already present, just change it to postgresql.
```
Also note in order to dump old competitions/users from mysql before switching to postgres ( this branch or pulling the latest once this gets merged ) use the following commands.:
`python manage.py dumdata web authenz --exclude=contenttypes --natural > db_test_dump.json` 
to dump the data for the web and authenz apps.

Once switched over to using postgres use the following on a fresh db ( See below for explanation on creating/destroying db )
```
python manage.py syncdb --migrate --no-initial-data --noinput
python manage.py sqlflush
python manage.py loaddata db_test_dump.json
```
Note: db_test_dump.json can be named anything for dumping/loading

For making sure your database is fresh/creating/destroying:
```
docker exec -it postgres bash
dropdb codalab_website
createdb codalab_website
exit -- To get out of postgres docker container
```

The above process was tested using the staging server mysql database, and was able to be loaded into my local codalab instance.
