### PR TITLE
Sanitize docker image string

### DIFF
--- a/codalab/apps/web/templates/web/competitions/_submit_results_page.html
+++ b/codalab/apps/web/templates/web/competitions/_submit_results_page.html
@@ -145,6 +145,18 @@
 
 <script>
     //**************************************************************//
+    //**                 docker image max length                  **//
+    //**************************************************************//
+    $('#submission_docker_image').keyup(function () {
+           var maxLength = 128;
+           var text = $(this).val();
+           var textLength = text.length;
+           if (textLength = maxLength) {
+               $(this).val(text.substring(0, (maxLength)));
+               alert("Sorry, only " + maxLength + " characters are allowed");
+           }
+       });
+    //**************************************************************//
     //**                 docker image local storage               **//
     //**************************************************************//
     var docker_image_key = window.location.href + '_docker_image'

--- a/codalab/apps/web/templates/web/competitions/_submit_results_page.html
+++ b/codalab/apps/web/templates/web/competitions/_submit_results_page.html
@@ -30,7 +30,7 @@
             <label class="control-label">Click the Submit button to upload a new submission.</label>
 
             <div class="form-group">
-                <input class="form-control" id="submission_docker_image" placeholder="Optional docker image name, eg codalab/default">
+                <input maxLength="128" class="form-control" id="submission_docker_image" placeholder="Optional docker image name, eg codalab/default">
             </div>
 
             {% if not phase.competition.enable_per_submission_metadata %}

--- a/codalab/apps/web/tests/test_docker_image_sanitation.py
+++ b/codalab/apps/web/tests/test_docker_image_sanitation.py
@@ -22,17 +22,3 @@ class DockerImageSanitationTests(TestCase):
         self._sanitize("continuumio/anaconda:4.3.0", "continuumio/anaconda:4.3.0")
         self._sanitize(" " * 100, "")
         self._sanitize(" " * 1000, "")
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/codalab/apps/web/tests/test_docker_image_sanitation.py
+++ b/codalab/apps/web/tests/test_docker_image_sanitation.py
@@ -1,0 +1,38 @@
+from django.test import TestCase
+from apps.web.utils import docker_image_clean
+
+
+class DockerImageSanitationTests(TestCase):
+
+    def _sanitize(self, str, result):
+        self.assertEquals(docker_image_clean(str), result)
+
+    def test_docker_image_sanitation(self):
+        # Baseline
+        self._sanitize("continuumio/anaconda:4.3.0", "continuumio/anaconda:4.3.0")
+        # Test cases
+        self._sanitize("      continuumio/anaconda:4.3.0           ", "continuumio/anaconda:4.3.0")
+        self._sanitize("###continuumio###/###anaconda:4.3.0###", "continuumio/anaconda:4.3.0")
+        self._sanitize("continuumio/anaconda:4.3.0 && sudo rm -rf /", "continuumio/anaconda:4.3.0")
+        self._sanitize("continuumio/anaconda:4.3.0 && ls -all || ls.txt", "continuumio/anaconda:4.3.0")
+        self._sanitize("continuumio/ anaconda:4.3.0", "continuumio/")
+        self._sanitize("'sudo bash'", "sudo")
+        self._sanitize("", "")
+        self._sanitize(" ", "")
+        self._sanitize("continuumio/anaconda:4.3.0", "continuumio/anaconda:4.3.0")
+        self._sanitize(" " * 100, "")
+        self._sanitize(" " * 1000, "")
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/codalab/apps/web/utils.py
+++ b/codalab/apps/web/utils.py
@@ -1,3 +1,5 @@
+import re
+
 from django.conf import settings
 from django.core.files.storage import get_storage_class
 
@@ -20,3 +22,13 @@ else:
     # No storage provided, like in a test, let's just do something basic
     BundleStorage = StorageClass()
     PublicStorage = StorageClass()
+
+
+def docker_image_clean(image_name):
+    # Remove all excess whitespaces on edges, split on spaces and grab the first word.
+    # Wraps in double quotes so bash cannot interpret as an exec
+    image_name = '"{}"'.format(image_name.strip().split(' ')[0])
+    # Regex acts as a whitelist here. Only alphanumerics and the following symbols are allowed: / . : -.
+    # If any not allowed are found, replaced with second argument to sub.
+    image_name = re.sub('[^0-9a-zA-Z/.:-]+', '', image_name)
+    return image_name

--- a/codalab/codalabtools/compute/worker.py
+++ b/codalab/codalabtools/compute/worker.py
@@ -298,10 +298,6 @@ def get_run_func():
         detailed_results_url = task_args['detailed_results_url']
         private_output_url = task_args['private_output_url']
 
-        """
-        DOCKER IMAGE SANITATION
-        """
-
         # Remove all excess whitespaces on edges, split on spaces and grab the first word.
         # Wraps in double quotes so bash cannot interpret as an exec
         sanitized_docker_image = '"{}"'.format(docker_image.strip().split(' ')[0])

--- a/codalab/codalabtools/compute/worker.py
+++ b/codalab/codalabtools/compute/worker.py
@@ -303,6 +303,7 @@ def get_run_func():
         """
 
         # Remove all excess whitespaces on edges, split on spaces and grab the first word.
+        # Wraps in double quotes so bash cannot interpret as an exec
         sanitized_docker_image = '"{}"'.format(docker_image.strip().split(' ')[0])
         # Regex acts as a whitelist here. Only alphanumerics and the following symbols are allowed: / . : -.
         # If any not allowed are found, replaced with second argument to sub.

--- a/codalab/codalabtools/compute/worker.py
+++ b/codalab/codalabtools/compute/worker.py
@@ -301,8 +301,11 @@ def get_run_func():
         """
         DOCKER IMAGE SANITATION
         """
-        sant_docker_image = '"{}"'.format(docker_image.strip().split(' ')[0])
-        sant_docker_image = re.sub('[^0-9a-zA-Z/.:]+', '', sant_docker_image)
+        # Remove all excess whitespaces on edges, split on spaces and grab the first word.
+        sanitized_docker_image = '"{}"'.format(docker_image.strip().split(' ')[0])
+        # Regex acts as a whitelist here. Only alphanumerics and the following symbols are allowed: / . : -.
+        # If any not allowed are found, replaced with second argument to sub.
+        sanitized_docker_image = re.sub('[^0-9a-zA-Z/.:-]+', '', sanitized_docker_image)
 
         execution_time_limit = task_args['execution_time_limit']
         # container = task_args['container_name']
@@ -435,7 +438,7 @@ def get_run_func():
                     # Set the right volume
                     '-v', '{0}:{0}'.format(run_dir),
                     # Set the right image
-                    sant_docker_image,
+                    sanitized_docker_image,
                 ]
                 prog_cmd = docker_cmd + prog_cmd
                 logger.info("Invoking program: %s", " ".join(prog_cmd))

--- a/codalab/codalabtools/compute/worker.py
+++ b/codalab/codalabtools/compute/worker.py
@@ -13,6 +13,7 @@ import pwd
 import grp
 import signal
 import math
+import re
 import shutil
 import socket
 import sys
@@ -297,6 +298,12 @@ def get_run_func():
         detailed_results_url = task_args['detailed_results_url']
         private_output_url = task_args['private_output_url']
 
+        """
+        DOCKER IMAGE SANITATION
+        """
+        sant_docker_image = '"{}"'.format(docker_image.strip().split(' ')[0])
+        sant_docker_image = re.sub('[^0-9a-zA-Z/.:]+', '', sant_docker_image)
+
         execution_time_limit = task_args['execution_time_limit']
         # container = task_args['container_name']
         is_predict_step = task_args.get("predict", False)
@@ -428,7 +435,7 @@ def get_run_func():
                     # Set the right volume
                     '-v', '{0}:{0}'.format(run_dir),
                     # Set the right image
-                    docker_image,
+                    sant_docker_image,
                 ]
                 prog_cmd = docker_cmd + prog_cmd
                 logger.info("Invoking program: %s", " ".join(prog_cmd))

--- a/codalab/codalabtools/compute/worker.py
+++ b/codalab/codalabtools/compute/worker.py
@@ -34,7 +34,7 @@ from celery.app import app_or_default
 sys.path.append(dirname(dirname(dirname(abspath(__file__)))))
 
 from codalabtools import BaseConfig
-
+from apps.web.utils import docker_image_clean
 
 logger = logging.getLogger('codalabtools')
 
@@ -298,12 +298,7 @@ def get_run_func():
         detailed_results_url = task_args['detailed_results_url']
         private_output_url = task_args['private_output_url']
 
-        # Remove all excess whitespaces on edges, split on spaces and grab the first word.
-        # Wraps in double quotes so bash cannot interpret as an exec
-        sanitized_docker_image = '"{}"'.format(docker_image.strip().split(' ')[0])
-        # Regex acts as a whitelist here. Only alphanumerics and the following symbols are allowed: / . : -.
-        # If any not allowed are found, replaced with second argument to sub.
-        sanitized_docker_image = re.sub('[^0-9a-zA-Z/.:-]+', '', sanitized_docker_image)
+        sanitized_docker_image = docker_image_clean(docker_image)
 
         execution_time_limit = task_args['execution_time_limit']
         # container = task_args['container_name']


### PR DESCRIPTION
Fixes docker image text field being exploitable.
- Splits on spaces, and uses the first word
- Removes remaining white-spaces/edges
- Removes non-alphanumeric characters ( Besides those found in docker image names )

Utilizes regex, and string formatting. 
