### PR TITLE
1876 Starting Kit Tab

### DIFF
--- a/codalab/apps/web/models.py
+++ b/codalab/apps/web/models.py
@@ -1605,26 +1605,32 @@ class CompetitionDefBundle(models.Model):
                 )
 
         participate_category = ContentCategory.objects.get(name="Participate")
-        Page.objects.create(category=participate_category,
-                            container=pc,
-                            codename="get_data",
-                            competition=comp,
-                            label="Get Data",
-                            rank=0,
-                            html=zf.read(comp_spec['html']['data']))
-        Page.objects.create(category=participate_category,
-                            container=pc,
-                            codename="get_starting_kit",
-                            competition=comp,
-                            label="Get Starting Kit",
-                            rank=2,
-                            html="")
-        Page.objects.create(category=participate_category,
-                            container=pc,
-                            codename="submit_results",
-                            label="Submit / View Results",
-                            rank=1,
-                            html="")
+        Page.objects.create(
+            category=participate_category,
+            container=pc,
+            codename="get_data",
+            competition=comp,
+            label="Get Data",
+            rank=0,
+            html=zf.read(comp_spec['html']['data'])
+        )
+        Page.objects.create(
+            category=participate_category,
+            container=pc,
+            codename="get_starting_kit",
+            competition=comp,
+            label="Get Starting Kit",
+            rank=2,
+            html=""
+        )
+        Page.objects.create(
+            category=participate_category,
+            container=pc,
+            codename="submit_results",
+            label="Submit / View Results",
+            rank=1,
+            html=""
+        )
         logger.debug("CompetitionDefBundle::unpack created competition pages (pk=%s)", self.pk)
 
         data_set_cache = {}

--- a/codalab/apps/web/models.py
+++ b/codalab/apps/web/models.py
@@ -309,6 +309,10 @@ class Competition(models.Model):
         if type(self.end_date) is datetime.datetime:
             return True if self.end_date is None else self.end_date > now()
 
+    @property
+    def has_starting_kit(self):
+        return self.phases.filter(starting_kit__isnull=False).exists()
+
     def check_future_phase_sumbmissions(self):
         '''
         Checks for if we need to migrate current phase submissions to next phase.'''
@@ -1601,9 +1605,26 @@ class CompetitionDefBundle(models.Model):
                 )
 
         participate_category = ContentCategory.objects.get(name="Participate")
-        Page.objects.create(category=participate_category, container=pc,  codename="get_data", competition=comp,
-                                   label="Get Data", rank=0, html=zf.read(comp_spec['html']['data']))
-        Page.objects.create(category=participate_category, container=pc,  codename="submit_results", label="Submit / View Results", rank=1, html="")
+        Page.objects.create(category=participate_category,
+                            container=pc,
+                            codename="get_data",
+                            competition=comp,
+                            label="Get Data",
+                            rank=0,
+                            html=zf.read(comp_spec['html']['data']))
+        Page.objects.create(category=participate_category,
+                            container=pc,
+                            codename="get_starting_kit",
+                            competition=comp,
+                            label="Get Starting Kit",
+                            rank=2,
+                            html="")
+        Page.objects.create(category=participate_category,
+                            container=pc,
+                            codename="submit_results",
+                            label="Submit / View Results",
+                            rank=1,
+                            html="")
         logger.debug("CompetitionDefBundle::unpack created competition pages (pk=%s)", self.pk)
 
         data_set_cache = {}

--- a/codalab/apps/web/static/less/main.less
+++ b/codalab/apps/web/static/less/main.less
@@ -309,3 +309,11 @@ label[for="image-clear_id"] {
     font-weight: bolder;
     color: green;
 }
+
+starting_kit_td {
+    padding-top: @navbar-height + 2px;
+}
+
+starting_kit_table {
+    border: 1px solid #000000;
+}

--- a/codalab/apps/web/templates/web/competitions/_get_starting_kit.html
+++ b/codalab/apps/web/templates/web/competitions/_get_starting_kit.html
@@ -2,39 +2,28 @@
 
 <h1>Starting Kits</h1>
 {% if competition.has_starting_kit %}
-{#    <table class="table table-responsive">#}
-{#        {% for phase in competition.phases.all %}#}
-{#            {% if phase and phase.starting_kit %}#}
-{#                <tr>#}
-{#                    <td><a href="{{ phase.get_starting_kit }}" class="btn btn-primary phase-btn-{{ phase.color }}">{{ phase.label }}</a></td>#}
-{#                </tr>#}
-{##}
-{#            {% endif %}#}
-{#        {% endfor %}#}
-{#    </table>#}
-
-            <table class="table table-responsive" style="border: 1px solid rgba(0, 0, 0, 0.1);">
-                <thead>
-                <th>
-                    Download
-                </th>
-                <th>
-                    Phase
-                </th>
-                </thead>
-                <tbody>
-                {% for phase in competition.phases.all %}
-                    {% if phase and phase.starting_kit %}
-                        <tr>
-                            <td>
-                                <a href="{{ phase.get_starting_kit }}" class="btn btn-primary phase-btn-{{ phase.color }}">{{phase.label}}</a>
-                            </td>
-                            <td style="padding-top: 12px;">#{{ phase.phasenumber }} {{ phase.label }}</td>
-                        </tr>
-                    {% endif %}
-                {% endfor %}
-                </tbody>
-            </table>
+    <table class="table table-responsive" style="border: 1px solid rgba(0, 0, 0, 0.1);">
+        <thead>
+        <th>
+            Download
+        </th>
+        <th>
+            Phase
+        </th>
+        </thead>
+        <tbody>
+        {% for phase in competition.phases.all %}
+            {% if phase and phase.starting_kit %}
+                <tr>
+                    <td>
+                        <a href="{{ phase.get_starting_kit }}" class="btn btn-primary phase-btn-{{ phase.color }}">{{phase.label}}</a>
+                    </td>
+                    <td style="padding-top: 12px;">#{{ phase.phasenumber }} {{ phase.label }}</td>
+                </tr>
+            {% endif %}
+        {% endfor %}
+        </tbody>
+    </table>
 {% else %}
     <i>No starting kits have been added for this competition yet.</i>
 {% endif %}

--- a/codalab/apps/web/templates/web/competitions/_get_starting_kit.html
+++ b/codalab/apps/web/templates/web/competitions/_get_starting_kit.html
@@ -2,7 +2,7 @@
 
 <h1>Starting Kits</h1>
 {% if competition.has_starting_kit %}
-    <table class="table table-responsive starting_kit_table">
+    <table style="border: 1px solid rgba(0,0,0,0.3)" class="table table-responsive">
         <thead>
         <th>
             Download
@@ -18,7 +18,7 @@
                     <td>
                         <a href="{{ phase.get_starting_kit }}" class="btn btn-primary phase-btn-{{ phase.color }}">{{phase.label}}</a>
                     </td>
-                    <td class="starting_kit_td">
+                    <td style="padding-top: 12px;">
                         #{{ phase.phasenumber }} {{ phase.label }}
                     </td>
                 </tr>

--- a/codalab/apps/web/templates/web/competitions/_get_starting_kit.html
+++ b/codalab/apps/web/templates/web/competitions/_get_starting_kit.html
@@ -1,0 +1,40 @@
+{% load codalab_tags %}
+
+<h1>Starting Kits</h1>
+{% if competition.has_starting_kit %}
+{#    <table class="table table-responsive">#}
+{#        {% for phase in competition.phases.all %}#}
+{#            {% if phase and phase.starting_kit %}#}
+{#                <tr>#}
+{#                    <td><a href="{{ phase.get_starting_kit }}" class="btn btn-primary phase-btn-{{ phase.color }}">{{ phase.label }}</a></td>#}
+{#                </tr>#}
+{##}
+{#            {% endif %}#}
+{#        {% endfor %}#}
+{#    </table>#}
+
+            <table class="table table-responsive" style="border: 1px solid rgba(0, 0, 0, 0.1);">
+                <thead>
+                <th>
+                    Download
+                </th>
+                <th>
+                    Phase
+                </th>
+                </thead>
+                <tbody>
+                {% for phase in competition.phases.all %}
+                    {% if phase and phase.starting_kit %}
+                        <tr>
+                            <td>
+                                <a href="{{ phase.get_starting_kit }}" class="btn btn-primary phase-btn-{{ phase.color }}">{{phase.label}}</a>
+                            </td>
+                            <td style="padding-top: 12px;">#{{ phase.phasenumber }} {{ phase.label }}</td>
+                        </tr>
+                    {% endif %}
+                {% endfor %}
+                </tbody>
+            </table>
+{% else %}
+    <i>No starting kits have been added for this competition yet.</i>
+{% endif %}

--- a/codalab/apps/web/templates/web/competitions/_get_starting_kit.html
+++ b/codalab/apps/web/templates/web/competitions/_get_starting_kit.html
@@ -2,7 +2,7 @@
 
 <h1>Starting Kits</h1>
 {% if competition.has_starting_kit %}
-    <table class="table table-responsive" style="border: 1px solid rgba(0, 0, 0, 0.1);">
+    <table class="table table-responsive starting_kit_table">
         <thead>
         <th>
             Download
@@ -18,7 +18,9 @@
                     <td>
                         <a href="{{ phase.get_starting_kit }}" class="btn btn-primary phase-btn-{{ phase.color }}">{{phase.label}}</a>
                     </td>
-                    <td style="padding-top: 12px;">#{{ phase.phasenumber }} {{ phase.label }}</td>
+                    <td class="starting_kit_td">
+                        #{{ phase.phasenumber }} {{ phase.label }}
+                    </td>
                 </tr>
             {% endif %}
         {% endfor %}

--- a/codalab/apps/web/templates/web/competitions/_innertabs.html
+++ b/codalab/apps/web/templates/web/competitions/_innertabs.html
@@ -12,7 +12,10 @@
                 <div class="tab-pane{% if forloop.first %} active{% endif %}" id="{{tab.codename|slugify}}-{{content.codename|slugify}}">
                     {% if content.codename == "submit_results" %}
                         {% include "web/competitions/_submit_results.html" with competition=competition user=user %}
+                    {% elif content.codename == "get_starting_kit" %}
+                        {% include "web/competitions/_get_starting_kit.html" with competition=competition user=user %}
                     {% else %}
+                        <h1>Get data</h1>
                         {{content.html|safe}}
                         {% if content.codename == "get_data" and competition.show_datasets_from_yaml %}
                             <!-- Include data for each phase if appropriate -->
@@ -31,7 +34,7 @@
                                     {% endif %}
                                 {% endfor %}
                             </ul>
-                        {% endif %}
+                            {% endif %}
                     {% endif %}
                 </div>
             {% endfor %}

--- a/codalab/apps/web/templates/web/competitions/_innertabs.html
+++ b/codalab/apps/web/templates/web/competitions/_innertabs.html
@@ -34,7 +34,7 @@
                                     {% endif %}
                                 {% endfor %}
                             </ul>
-                            {% endif %}
+                        {% endif %}
                     {% endif %}
                 </div>
             {% endfor %}

--- a/codalab/apps/web/templates/web/competitions/_submit_results.html
+++ b/codalab/apps/web/templates/web/competitions/_submit_results.html
@@ -1,4 +1,7 @@
 {% load codalab_tags %}
+
+<h1>Submit or view results</h1>
+
 <div id="submissions_phase_buttons">
   {% for phase in competition.phases.all %}
     {% if phase == active_phase %}

--- a/codalab/apps/web/templates/web/competitions/view.html
+++ b/codalab/apps/web/templates/web/competitions/view.html
@@ -76,9 +76,6 @@
                                 <h4><span class="glyphicon glyphicon-play"></span> Current</h4>
                                 <span class="phase-label label phase-label-{% if active_phase.color %}{{ active_phase.color }}{% else %}default{% endif %}">{{active_phase.label}}</span>
                                 <div class="date">{{active_phase.start_date|utc}} UTC</div>
-                                {% if active_phase and active_phase.starting_kit %}
-                                    <a href="{{ active_phase.get_starting_kit }}" class="btn btn-primary">Download Starting Kit</a>
-                                {% endif %}
                             </div>
                         </div>
                     {% endif %}

--- a/codalab/codalab/settings/base.py
+++ b/codalab/codalab/settings/base.py
@@ -572,6 +572,7 @@ class Base(Settings):
     # Docker
     # =========================================================================
     DOCKER_DEFAULT_WORKER_IMAGE = "ckcollab/codalab-legacy"
+    DEFAULT_WORKER_DOCKER_IMAGE = "ckcollab/codalab-legacy"
     DOCKER_MAX_SIZE_GB = 10.0
     
     # =========================================================================

--- a/codalab/codalab/settings/base.py
+++ b/codalab/codalab/settings/base.py
@@ -572,7 +572,6 @@ class Base(Settings):
     # Docker
     # =========================================================================
     DOCKER_DEFAULT_WORKER_IMAGE = "ckcollab/codalab-legacy"
-    DEFAULT_WORKER_DOCKER_IMAGE = "ckcollab/codalab-legacy"
     DOCKER_MAX_SIZE_GB = 10.0
     
     # =========================================================================


### PR DESCRIPTION
Creates a new tab under the `participate` category of a competition view. ( Only if the competition has a `starting_kit` )

<img width="993" alt="screen shot 2017-07-28 at 9 13 26 pm" src="https://user-images.githubusercontent.com/28552312/28742033-aefa1b5a-73d9-11e7-82fa-b2ed4d491c99.png">


Holds a table which contains a link to download each `starting_kit` for each phase, if it exists.

- [ ] move style stuff into stylesheets
---- ----

### Testing 

Function: On a competition with a `starting_kit` set in at least one phase, you should be able to view this tab and download the applicable `starting_kit` for the phase.

Logging: Watching all containers or `django` should be fine for finding errors.

See http://codalab-competitions.readthedocs.io/en/1871-add-debug-to-docs/Debugging/ for info on how to view logs.

Expected Results: The `starting_kit(s)` should have their own tab under the `participate` category of a competition view. This should be an organized table with relevant phase information for each `starting_kit` listed. These download links should return the proper phase specific `starting_kit`. Anything else should not be happening.

