### PR TITLE
Replaces leadeboard link with dumps

### DIFF
--- a/codalab/apps/web/templates/web/my/_competition_tile.html
+++ b/codalab/apps/web/templates/web/my/_competition_tile.html
@@ -44,7 +44,7 @@
 				<a class="btn btn-sm btn-warning competition-unpublish-button {% if not competition.published %}hide{% endif %}" href="{% url 'competition-unpublish' pk=competition.pk %}">Unpublish</a>
                 <a class="btn btn-sm btn-primary" href="{% url 'my_competition_participants' competition_id=competition.pk %}">Participants</a>
 				<a class="btn btn-sm btn-primary" href="{% url 'my_competition_submissions' competition_id=competition.pk %}">Submissions</a>
-				<a class="btn btn-sm btn-primary" href="/competitions/{{competition.pk}}#results">Leaderboard</a>
+                <a class="btn btn-sm btn-primary" href="{% url 'competitions:dumps' competition_pk=competition.pk %}">Dumps</a>
 			</div>
 		</div>
     	{% endif %}


### PR DESCRIPTION
Under my Competitions, replaces `leaderboards` button on a competition tile with a `dumps` button that links you to a Competitions Export/Dump page.