### PR TITLE
Better YAML format, small issue fix

### DIFF
--- a/codalab/apps/web/models.py
+++ b/codalab/apps/web/models.py
@@ -2149,10 +2149,9 @@ class CompetitionDump(models.Model):
 
     def get_size_mb(self):
         if self.status == "Finished":
-            return float(self.data_file.size) * 0.000001
+            return float(self.data_file.size) * 0.00000095367432
         else:
             return 0
-
 
     def sassy_url(self):
         from apps.web.tasks import _make_url_sassy

--- a/codalab/apps/web/models.py
+++ b/codalab/apps/web/models.py
@@ -2147,6 +2147,13 @@ class CompetitionDump(models.Model):
         null=True,
     )
 
+    def get_size_mb(self):
+        if self.status == "Finished":
+            return float(self.data_file.size) * 0.000001
+        else:
+            return 0
+
+
     def sassy_url(self):
         from apps.web.tasks import _make_url_sassy
         return _make_url_sassy(self.data_file.name)

--- a/codalab/apps/web/tasks.py
+++ b/codalab/apps/web/tasks.py
@@ -14,6 +14,7 @@ from urllib import pathname2url
 
 from yaml.representer import SafeRepresenter
 from zipfile import ZipFile
+from collections import OrderedDict
 
 import sys
 
@@ -799,7 +800,6 @@ def do_phase_migrations():
 @task(queue='site-worker', soft_time_limit=60 * 60 * 24)
 def make_modified_bundle(competition_pk):
     # The following lines help dump this in a nice format
-    from collections import OrderedDict
     _mapping_tag = yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG
 
     def dict_representer(dumper, data):
@@ -807,7 +807,8 @@ def make_modified_bundle(competition_pk):
 
     def dict_constructor(loader, node):
         return OrderedDict(loader.construct_pairs(node))
-    #Credit to miracle2k on Github for orderdict safe dump
+    # Credit to miracle2k on Github for orderdict safe dump
+
     def represent_odict(dump, tag, mapping, flow_style=None):
         """Like BaseRepresenter.represent_mapping, but does not issue the sort().
         """

--- a/codalab/apps/web/tasks.py
+++ b/codalab/apps/web/tasks.py
@@ -798,7 +798,7 @@ def do_phase_migrations():
 
 @task(queue='site-worker', soft_time_limit=60 * 60 * 24)
 def make_modified_bundle(competition_pk):
-
+    # The following lines help dump this in a nice format
     from collections import OrderedDict
     _mapping_tag = yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG
 
@@ -807,7 +807,33 @@ def make_modified_bundle(competition_pk):
 
     def dict_constructor(loader, node):
         return OrderedDict(loader.construct_pairs(node))
-
+    #Credit to miracle2k on Github for orderdict safe dump
+    def represent_odict(dump, tag, mapping, flow_style=None):
+        """Like BaseRepresenter.represent_mapping, but does not issue the sort().
+        """
+        value = []
+        node = yaml.MappingNode(tag, value, flow_style=flow_style)
+        if dump.alias_key is not None:
+            dump.represented_objects[dump.alias_key] = node
+        best_style = True
+        if hasattr(mapping, 'items'):
+            mapping = mapping.items()
+        for item_key, item_value in mapping:
+            node_key = dump.represent_data(item_key)
+            node_value = dump.represent_data(item_value)
+            if not (isinstance(node_key, yaml.ScalarNode) and not node_key.style):
+                best_style = False
+            if not (isinstance(node_value, yaml.ScalarNode) and not node_value.style):
+                best_style = False
+            value.append((node_key, node_value))
+        if flow_style is None:
+            if dump.default_flow_style is not None:
+                node.flow_style = dump.default_flow_style
+            else:
+                node.flow_style = best_style
+        return node
+    yaml.SafeDumper.add_representer(OrderedDict,
+                                    lambda dumper, value: represent_odict(dumper, u'tag:yaml.org,2002:map', value))
     # Following line supresses the broadexception warning. We catch and do a traceback for now from logs.
     # noinspection PyBroadException
     try:
@@ -934,10 +960,9 @@ def make_modified_bundle(competition_pk):
         temp_comp_dump.status = "Finalizing"
         temp_comp_dump.save()
         logger.info("Finalizing")
-        comp_yaml_my_dump = yaml.dump(yaml_data, default_flow_style=False, allow_unicode=True, encoding="utf-8")
-        yaml_data = yaml.load(comp_yaml_my_dump)
+        comp_yaml_my_dump = yaml.safe_dump(yaml_data, default_flow_style=False, allow_unicode=True, encoding="utf-8")
         zip_file.writestr(yaml_data["image"], competition.image.file.read())
-        zip_file.writestr("competition.yaml", yaml.dump(yaml_data))
+        zip_file.writestr("competition.yaml", comp_yaml_my_dump)
         zip_file.close()
         logger.info("Stored Zip buffer yaml dump, and image")
         logger.info("Attempting to save ZIP")

--- a/codalab/apps/web/templates/web/competitions/_innertabs.html
+++ b/codalab/apps/web/templates/web/competitions/_innertabs.html
@@ -15,7 +15,9 @@
                     {% elif content.codename == "get_starting_kit" %}
                         {% include "web/competitions/_get_starting_kit.html" with competition=competition user=user %}
                     {% else %}
-                        <h1>Get data</h1>
+                        {% if content.codename == 'get_data' %}
+                            <h1>Get data</h1>
+                        {% endif %}
                         {{ content.processed_html|safe }}
                         {% if content.codename == "get_data" and competition.show_datasets_from_yaml %}
                             <!-- Include data for each phase if appropriate -->

--- a/codalab/apps/web/templates/web/competitions/delete_dump_confirm.html
+++ b/codalab/apps/web/templates/web/competitions/delete_dump_confirm.html
@@ -1,0 +1,13 @@
+{% extends "base.html" %}
+{% block page_title %}Competition Dumps{% endblock %}
+{% block head_title %}Competition Dumps{% endblock %}
+
+{% block content %}
+
+    <p>Are you sure you wish to delete this Competition Dump?</p>
+    <form method="post">
+        {% csrf_token %}
+        <button type="submit" class="btn btn-danger">Yes, I'm sure.</button>
+    </form>
+
+{% endblock %}

--- a/codalab/apps/web/templates/web/competitions/dumps.html
+++ b/codalab/apps/web/templates/web/competitions/dumps.html
@@ -17,6 +17,7 @@
                     <td width="100px"><h5><b>Status</b></h5></td>
                     <td width="100px"><h5><b>Size</b></h5></td>
                     <td width="400px"><h5><b>Publish Date</b></h5></td>
+                    <td width="400px"><h5><b>Delete</b></h5></td>
                 </thead>
                     <tbody>
                         <tr id="dump-table-data">
@@ -37,6 +38,9 @@
                                 </td>
                                 <td>
                                     <i>{{ dump.timestamp }}</i>
+                                </td>
+                                <td>
+                                    <a href="{% url 'competitions:delete_dump' pk=dump.pk %}" class="btn btn-danger btn-xs">Delete</a>
                                 </td>
                                 {% if forloop.counter|divisibleby:1 %}</tr>{% endif %}
                             {% endfor %}

--- a/codalab/apps/web/templates/web/competitions/dumps.html
+++ b/codalab/apps/web/templates/web/competitions/dumps.html
@@ -4,15 +4,18 @@
 
 {% block content %}
     <a href="{% url "competitions:view" pk=competition.pk %}" >Go Back to Competition Homepage</a>
+    <i>Note: Refresh the page to view updates.</i>
     <div class="panel">
         <div class="panel-body">
             <button id="make_dump" class="btn btn-primary">Create Competition Dump</button>
+            <button id="refresh_page" class="btn btn-primary">Refresh the Page</button>
             {% if dumps %}
                 <h1>Dumps for: {{ competition.title }}</h1>
                 <table id="dump-table" class="table table-responsive">
                 <thead>
                     <td width="100px"><h5><b>Download link</b></h5></td>
                     <td width="100px"><h5><b>Status</b></h5></td>
+                    <td width="100px"><h5><b>Size</b></h5></td>
                     <td width="400px"><h5><b>Publish Date</b></h5></td>
                 </thead>
                     <tbody>
@@ -26,6 +29,11 @@
                                 </td>
                                 <td>
                                     <b>{{ dump.status }}</b>
+                                </td>
+                                <td>
+                                    {% if dump.status == "Finished" %}
+                                        <b>{{ dump.get_size_mb|floatformat:2 }} mb</b>
+                                    {% endif %}
                                 </td>
                                 <td>
                                     <i>{{ dump.timestamp }}</i>
@@ -42,16 +50,20 @@
         </div>
     </div>
     <script>
+        $('#refresh_page').click(function() {
+            location.reload(true)
+        });
+
         $(document).ready(function() {
             $("#make_dump").click(function() {
                 var url = "{% url 'competitions:make_bundle' competition_pk=competition.pk %}"
                 $.post(url)
-                    .success(function() {
-                        location.reload(true)
-                    })
-                    .error(function() {
-                        alert("There was a problem generating the dump. Please make sure you're connected to the Internet, if the problem persists please contact an admin.")
-                    })
+                .success(function() {
+                    location.reload(true)
+                })
+                .error(function() {
+                    alert("There was a problem generating the dump. Please make sure you're connected to the Internet, if the problem persists please contact an admin.")
+                })
             })
         })
     </script>

--- a/codalab/apps/web/tests/test_competitions.py
+++ b/codalab/apps/web/tests/test_competitions.py
@@ -199,6 +199,7 @@ class CompetitionDeleteTests(CompetitionTest):
 class CompetitionDumpDeleteTests(CompetitionTest):
 
     def setUp(self):
+        super(CompetitionDumpDeleteTests, self).setUp()
         zip_buffer = StringIO.StringIO()
         zip_name = "{0}.zip".format("Example_Title")
         zip_file = zipfile.ZipFile(zip_buffer, "w")

--- a/codalab/apps/web/urls/competitions.py
+++ b/codalab/apps/web/urls/competitions.py
@@ -33,7 +33,7 @@ urlpatterns = patterns(
     url(r'^submission_migrate/(?P<pk>\d+)', views.submission_migrate, name="submission_migrate"),
     url(r'^public_submissions/(?P<pk>\d+)$', views.CompetitionPublicSubmission.as_view(), name='public_submissions'),
     url(r'^(?P<pk>\d+)/public_submissions/(?P<phase>\d+)$', views.CompetitionPublicSubmissionByPhases.as_view(), name='public_submissions_phase'),
-    url(r'^(?P<competition_pk>\d+)/dumps/$', views.competition_dumps_view,
-        name='dumps'),
+    url(r'^(?P<competition_pk>\d+)/dumps/$', views.competition_dumps_view, name='dumps'),
+    url(r'^(?P<pk>\d+)/delete_dump/$', views.CompetitionDumpDeleteView.as_view(), name="delete_dump"),
 
 )

--- a/codalab/apps/web/views.py
+++ b/codalab/apps/web/views.py
@@ -1855,7 +1855,7 @@ def competition_dumps_view(request, competition_pk):
 @login_required
 def start_make_bundle_task(request, competition_pk):
     competition = models.Competition.objects.get(pk=competition_pk)
-    if request.user.id != competition.creator_id and request.user not in competition.admins.all():
+    if request.user != competition.creator and request.user not in competition.admins.all():
         raise Http404()
     make_modified_bundle.apply_async((competition.pk,))
     return HttpResponse()

--- a/codalab/apps/web/views.py
+++ b/codalab/apps/web/views.py
@@ -22,9 +22,9 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.core.exceptions import PermissionDenied
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 from django.core.servers.basehttp import FileWrapper
-from django.core.urlresolvers import reverse
+from django.core.urlresolvers import reverse, reverse_lazy
 from django.db.models import Q, Max, Min, Count
-from django.http import Http404
+from django.http import Http404, HttpResponseForbidden
 from django.http import HttpResponse, HttpResponseRedirect
 from django.http import StreamingHttpResponse
 from django.shortcuts import render_to_response, render
@@ -1859,3 +1859,21 @@ def start_make_bundle_task(request, competition_pk):
         raise Http404()
     make_modified_bundle.apply_async((competition.pk,))
     return HttpResponse()
+
+class CompetitionDumpDeleteView(DeleteView):
+    model = models.CompetitionDump
+    template_name = 'web/competitions/delete_dump_confirm.html'
+
+    def dispatch(self, request, *args, **kwargs):
+        pk = kwargs.get('pk')
+        dump = models.CompetitionDump.objects.get(pk=pk)
+        competition = dump.competition
+        user = request.user
+        if user.id != competition.creator.id and user not in competition.admins.all():
+            return HttpResponseForbidden()
+        else:
+            return super(CompetitionDumpDeleteView, self).dispatch(request, *args, **kwargs)
+
+    def get_success_url(self):
+        dump = self.object
+        return reverse('competitions:dumps', kwargs={'competition_pk': dump.competition.pk})


### PR DESCRIPTION
Format changes to competition yaml:
- [x] No `!!Python` tags
- [x] In order now

CompetitionDump view changes:
- [x] Delete button
    - [x] Check permissions
    - [x] Tests
    - [x] Make sure delete is done correctly

- [x] File size in mb

Small Issue:
    - Fix `Get Data` header appearing on every HTML content.