### PR TITLE
Starting Kit: Change tab order, change table, change page name, etc

### DIFF
--- a/codalab/apps/web/forms.py
+++ b/codalab/apps/web/forms.py
@@ -89,7 +89,7 @@ class CompetitionPhaseForm(forms.ModelForm):
             'scoring_program_organizer_dataset',
             'phase_never_ends',
             'force_best_submission_to_leaderboard',
-            'starting_kit',
+            'starting_kit_organizer_dataset',
             'scoring_program_docker_image',
             'default_docker_image',
             'disable_custom_docker_image',

--- a/codalab/apps/web/models.py
+++ b/codalab/apps/web/models.py
@@ -314,7 +314,7 @@ class Competition(models.Model):
 
     @property
     def has_starting_kit(self):
-        return self.phases.filter(starting_kit__isnull=False).exists()
+        return self.phases.filter(starting_kit_organizer_dataset__isnull=False).exists()
 
     def check_future_phase_sumbmissions(self):
         '''
@@ -812,7 +812,10 @@ class CompetitionPhase(models.Model):
 
     def get_starting_kit(self):
         from apps.web.tasks import _make_url_sassy
-        return _make_url_sassy(self.starting_kit.name)
+        return _make_url_sassy(self.starting_kit_organizer_dataset.data_file.name)
+
+    def get_starting_kit_size_mb(self):
+        return float(self.starting_kit_organizer_dataset.data_file.size) * 0.00000095367432
 
     class Meta:
         ordering = ['phasenumber']
@@ -1620,7 +1623,7 @@ class CompetitionDefBundle(models.Model):
             codename="get_data",
             competition=comp,
             label="Get Data",
-            rank=0,
+            rank=1,
             html=zf.read(comp_spec['html']['data'])
         )
         Page.objects.create(
@@ -1628,8 +1631,8 @@ class CompetitionDefBundle(models.Model):
             container=pc,
             codename="get_starting_kit",
             competition=comp,
-            label="Get Starting Kit",
-            rank=2,
+            label="Files",
+            rank=0,
             html=""
         )
         Page.objects.create(
@@ -1637,7 +1640,7 @@ class CompetitionDefBundle(models.Model):
             container=pc,
             codename="submit_results",
             label="Submit / View Results",
-            rank=1,
+            rank=2,
             html=""
         )
         logger.debug("CompetitionDefBundle::unpack created competition pages (pk=%s)", self.pk)

--- a/codalab/apps/web/templates/web/competitions/_get_starting_kit.html
+++ b/codalab/apps/web/templates/web/competitions/_get_starting_kit.html
@@ -1,6 +1,6 @@
 {% load codalab_tags %}
 
-<h1>Starting Kits</h1>
+<h1>Files</h1>
 {% if competition.has_starting_kit %}
     <table style="border: 1px solid rgba(0,0,0,0.3)" class="table table-responsive">
         <thead>
@@ -8,15 +8,27 @@
             Download
         </th>
         <th>
+            Size ( mb )
+        </th>
+        <th>
+            Filetype:
+        </th>
+        <th>
             Phase
         </th>
         </thead>
         <tbody>
         {% for phase in competition.phases.all %}
-            {% if phase and phase.starting_kit %}
+            {% if phase and phase.starting_kit_organizer_dataset %}
                 <tr>
                     <td>
                         <a href="{{ phase.get_starting_kit }}" class="btn btn-primary phase-btn-{{ phase.color }}">{{phase.label}}</a>
+                    </td>
+                    <td style="padding-top: 12px;">
+                        {{ phase.get_starting_kit_size_mb|floatformat:3 }}
+                    </td>
+                    <td style="padding-top: 12px;">
+                        {{ phase.starting_kit_organizer_dataset.type }}
                     </td>
                     <td style="padding-top: 12px;">
                         #{{ phase.phasenumber }} {{ phase.label }}
@@ -27,5 +39,5 @@
         </tbody>
     </table>
 {% else %}
-    <i>No starting kits have been added for this competition yet.</i>
+    <i>No files have been added for this competition yet.</i>
 {% endif %}

--- a/codalab/apps/web/templates/web/competitions/_get_starting_kit.html
+++ b/codalab/apps/web/templates/web/competitions/_get_starting_kit.html
@@ -8,7 +8,7 @@
             Download
         </th>
         <th>
-            Size ( mb )
+            Size (mb)
         </th>
         <th>
             Filetype:


### PR DESCRIPTION
Tweaks to starting Kit discussed with Isabelle:
- Rename Starting Kit tab to files
- Add size in mb to starting kit table
- Add file type in starting kit table ( See organizer dataset types )
- Edit page for competitions now uses Organizer datasets.

<img width="999" alt="screen shot 2017-08-21 at 10 30 04 am" src="https://user-images.githubusercontent.com/28552312/29531155-23b6cdd2-865c-11e7-88d9-cee29ced95d2.png">
