### PR TITLE
add django-pin-passcode for debug versions of codalab

### DIFF
--- a/codalab/codalab/settings/base.py
+++ b/codalab/codalab/settings/base.py
@@ -240,6 +240,9 @@ class Base(Settings):
         # Search
         'haystack',
         'django_extensions',
+
+        # Lockout
+        'pin_passcode',
     )
 
     ACCOUNT_ADAPTER = ("apps.authenz.adapter.CodalabAccountAdapter")
@@ -612,6 +615,7 @@ class Base(Settings):
         if cls.SERVER_NAME not in cls.ALLOWED_HOSTS:
             cls.ALLOWED_HOSTS.append(cls.SERVER_NAME)
 
+
 class DevBase(Base):
 
     if os.environ.get('DEBUG', False):
@@ -625,11 +629,15 @@ class DevBase(Base):
         }
         EXTRA_MIDDLEWARE_CLASSES = (
             'debug_toolbar.middleware.DebugToolbarMiddleware',
-            'userswitch.middleware.UserSwitchMiddleware',)
+            'userswitch.middleware.UserSwitchMiddleware',
+            'pin_passcode.middleware.PinPasscodeMiddleware',
+        )
         DEBUG_TOOLBAR_CONFIG = {
             'SHOW_TEMPLATE_CONTEXT': True,
             'ENABLE_STACKTRACES' : True,
         }
+
+        PIN_PASSCODE_PIN = 1234
         # Increase amount of logging output in Dev mode.
         # for logger_name in ('codalab', 'apps'):
         #     Base.LOGGING['loggers'][logger_name]['level'] = 'DEBUG'

--- a/codalab/codalab/settings/base.py
+++ b/codalab/codalab/settings/base.py
@@ -630,14 +630,17 @@ class DevBase(Base):
         EXTRA_MIDDLEWARE_CLASSES = (
             'debug_toolbar.middleware.DebugToolbarMiddleware',
             'userswitch.middleware.UserSwitchMiddleware',
-            'pin_passcode.middleware.PinPasscodeMiddleware',
         )
         DEBUG_TOOLBAR_CONFIG = {
             'SHOW_TEMPLATE_CONTEXT': True,
-            'ENABLE_STACKTRACES' : True,
+            'ENABLE_STACKTRACES': True,
         }
 
-        PIN_PASSCODE_PIN = 1234
+        if os.environ.get('PIN_PASSCODE_ENABLED', False):
+            EXTRA_MIDDLEWARE_CLASSES += ('pin_passcode.middleware.PinPasscodeMiddleware',)
+            PIN_PASSCODE_PIN = os.environ.get('PIN_PASSCODE_PIN', 1234)
+            PIN_PASSCODE_IP_WHITELIST = ('127.0.0.1', 'localhost',)
+
         # Increase amount of logging output in Dev mode.
         # for logger_name in ('codalab', 'apps'):
         #     Base.LOGGING['loggers'][logger_name]['level'] = 'DEBUG'

--- a/codalab/codalab/urls.py
+++ b/codalab/codalab/urls.py
@@ -24,6 +24,8 @@ urlpatterns = patterns('',
     # Uncomment the next line to enable the admin:
     # url(r'^admin/', include(admin.site.urls)),
 
+    url(r'^', include('pin_passcode.urls')),
+
     # Static files
     url(r'^static/(?P<path>.*)$', 'django.views.static.serve',
         {'document_root': settings.STATIC_ROOT}),

--- a/codalab/requirements/common.txt
+++ b/codalab/requirements/common.txt
@@ -66,6 +66,9 @@ git+https://github.com/FlavioAlexander/azure-sdk-for-python.git@legacy
 # Required when PostgreSQL is used
 psycopg2==2.7.1
 
+# Lock unwanted people out on staging servers
+django-pin-passcode==0.1.9
+
 # Adding test libraries here for simplicity sake
 pytest==3.0.6
 pytest-django==2.9.1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -110,6 +110,7 @@ services:
     env_file: .env
     environment:
       - CONFIG_SERVER_NAME=${CODALAB_SITE_DOMAIN}
+      - PYTHONUNBUFFERED=0
     links:
       - postgres
       - rabbit


### PR DESCRIPTION
Resoles #1922 

- [x] Make localhost be allowed through

Now requires opt-in via env var