### PR TITLE
Competition Dumping: No image bug fix

### DIFF
--- a/codalab/apps/web/tasks.py
+++ b/codalab/apps/web/tasks.py
@@ -866,11 +866,9 @@ def make_modified_bundle(competition_pk, exclude_datasets_flag):
         yaml_data = OrderedDict()
         yaml_data['title'] = competition.title
         yaml_data['description'] = competition.description.replace("/n", "").replace("\"", "").strip()
-        try:
-            if competition.logo.file:
-                yaml_data['image'] = 'logo.png'
-        except ValueError:
-            print("No image for competition.")
+        if competition.logo:
+            yaml_data['image'] = 'logo.png'
+        else:
             logger.info("No image for competition.")
         yaml_data['has_registration'] = competition.has_registration
         yaml_data['html'] = dict()
@@ -1001,10 +999,9 @@ def make_modified_bundle(competition_pk, exclude_datasets_flag):
         temp_comp_dump.save()
         logger.info("Finalizing")
         comp_yaml_my_dump = yaml.safe_dump(yaml_data, default_flow_style=False, allow_unicode=True, encoding="utf-8")
-        try:
+        if competition.image:
             zip_file.writestr(yaml_data["image"], competition.image.file.read())
-        except ValueError:
-            print("No image for competition.")
+        else:
             logger.info("No image for competition.")
         zip_file.writestr("competition.yaml", comp_yaml_my_dump)
         zip_file.close()

--- a/codalab/apps/web/tasks.py
+++ b/codalab/apps/web/tasks.py
@@ -12,6 +12,7 @@ import zipfile
 
 from urllib import pathname2url
 
+from django.core.exceptions import ObjectDoesNotExist
 from yaml.representer import SafeRepresenter
 from zipfile import ZipFile
 from collections import OrderedDict
@@ -865,7 +866,12 @@ def make_modified_bundle(competition_pk, exclude_datasets_flag):
         yaml_data = OrderedDict()
         yaml_data['title'] = competition.title
         yaml_data['description'] = competition.description.replace("/n", "").replace("\"", "").strip()
-        yaml_data['image'] = 'logo.png'
+        try:
+            if competition.logo.file:
+                yaml_data['image'] = 'logo.png'
+        except ValueError:
+            print("No image for competition.")
+            logger.info("No image for competition.")
         yaml_data['has_registration'] = competition.has_registration
         yaml_data['html'] = dict()
         yaml_data['phases'] = {}
@@ -995,7 +1001,11 @@ def make_modified_bundle(competition_pk, exclude_datasets_flag):
         temp_comp_dump.save()
         logger.info("Finalizing")
         comp_yaml_my_dump = yaml.safe_dump(yaml_data, default_flow_style=False, allow_unicode=True, encoding="utf-8")
-        zip_file.writestr(yaml_data["image"], competition.image.file.read())
+        try:
+            zip_file.writestr(yaml_data["image"], competition.image.file.read())
+        except ValueError:
+            print("No image for competition.")
+            logger.info("No image for competition.")
         zip_file.writestr("competition.yaml", comp_yaml_my_dump)
         zip_file.close()
         logger.info("Stored Zip buffer yaml dump, and image")


### PR DESCRIPTION
Adds a check to make sure a competition has an image. If not, the field is not added.

- Dump no longer fails if competition has no image.