### PR TITLE
Fix typo in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To start the compute worker under project directory:
 
 If for some reason you need to rebuild the image run:
 
-`docker-compuse up --build worker`
+`docker-compose up --build worker`
 
 
 ## Tests


### PR DESCRIPTION
There's a typo in one of the commands.
It's `docker-compose` not `docker-compuse`.