### PR TITLE
Fix not being able to download combined datasets from files page

### DIFF
--- a/codalab/apps/web/models.py
+++ b/codalab/apps/web/models.py
@@ -860,14 +860,24 @@ class CompetitionPhase(models.Model):
         return _make_url_sassy(self.starting_kit_organizer_dataset.data_file.name)
 
     def get_starting_kit_size_mb(self):
-        return float(self.starting_kit_organizer_dataset.data_file.size) * 0.00000095367432
+        size = float(self.starting_kit_organizer_dataset.data_file.size)
+        if self.starting_kit_organizer_dataset.sub_data_files and len(self.starting_kit_organizer_dataset.sub_data_files.all()) > 0:
+            size = float(0)
+            for sub_data in self.starting_kit_organizer_dataset.sub_data_files.all():
+                size += float(sub_data.data_file.size)
+        return size * 0.00000095367432
 
     def get_public_data(self):
         from apps.web.tasks import _make_url_sassy
         return _make_url_sassy(self.public_data_organizer_dataset.data_file.name)
 
     def get_public_data_size_mb(self):
-        return float(self.public_data_organizer_dataset.data_file.size) * 0.00000095367432
+        size = float(self.public_data_organizer_dataset.data_file.size)
+        if self.public_data_organizer_dataset.sub_data_files and len(self.public_data_organizer_dataset.sub_data_files.all()) > 0:
+            size = float(0)
+            for sub_data in self.public_data_organizer_dataset.sub_data_files.all():
+                size += float(sub_data.data_file.size)
+        return size * 0.00000095367432
 
     class Meta:
         ordering = ['phasenumber']

--- a/codalab/apps/web/templates/web/competitions/_get_starting_kit.html
+++ b/codalab/apps/web/templates/web/competitions/_get_starting_kit.html
@@ -22,7 +22,7 @@
             {% if phase and phase.starting_kit_organizer_dataset %}
                 <tr>
                     <td>
-                        <a href="{{ phase.get_starting_kit }}" class="btn btn-primary phase-btn-{{ phase.color }}">{{phase.label}}</a>
+                        <a href="{% url 'datasets_download' dataset_key=phase.starting_kit_organizer_dataset.key %}" class="btn btn-primary phase-btn-{{ phase.color }}">{{phase.label}}</a>
                     </td>
                     <td style="padding-top: 12px;">
                         {{ phase.get_starting_kit_size_mb|floatformat:3 }}
@@ -38,7 +38,7 @@
             {% if phase and phase.public_data_organizer_dataset %}
                 <tr>
                     <td>
-                        <a href="{{ phase.get_public_data }}" class="btn btn-primary phase-btn-{{ phase.color }}">{{phase.label}}</a>
+                        <a href="{% url 'datasets_download' dataset_key=phase.public_data_organizer_dataset.key %}" class="btn btn-primary phase-btn-{{ phase.color }}">{{phase.label}}</a>
                     </td>
                     <td style="padding-top: 12px;">
                         {{ phase.get_public_data_size_mb|floatformat:3 }}


### PR DESCRIPTION
- [ ] Changes files tab template to use download dataset view ( Has logic for combined vs un-combined )
- [ ] Change get_size to check for sub_datasets, and return the correct size.

<img width="858" alt="screen shot 2017-11-03 at 5 05 28 pm" src="https://user-images.githubusercontent.com/28552312/32400161-0a508926-c0ba-11e7-97fe-461c45391bf2.png">
