### PR TITLE
Phase migrations: Submission docker images.

### DIFF
--- a/codalab/apps/web/models.py
+++ b/codalab/apps/web/models.py
@@ -408,7 +408,8 @@ class Competition(models.Model):
                 new_submission = CompetitionSubmission(
                     participant=participant,
                     file=submission.file,
-                    phase=next_phase
+                    phase=next_phase,
+                    docker_image=submission.docker_image,
                 )
                 new_submission.save(ignore_submission_limits=True)
 


### PR DESCRIPTION
- [ ] Submission docker_images should carry over now with migration. Simply needed to tell the new submission on the phase to use docker image. 