### PR TITLE
Detailed Results Empty/Metadata file fix

### DIFF
--- a/codalab/apps/web/tasks.py
+++ b/codalab/apps/web/tasks.py
@@ -503,7 +503,7 @@ def score(submission, job_id):
     # Pre-save files so we can overwrite their names later
     submission.output_file.save('output_file.zip', ContentFile(''))
     submission.private_output_file.save('private_output_file.zip', ContentFile(''))
-    submission.detailed_results_file.save('detailed_results_file.zip', ContentFile(''))
+    submission.detailed_results_file.save('detailed_results_file.html', ContentFile(''))
     submission.save()
     # Submit the request to the computation service
     _prepare_compute_worker_run(job_id, submission, is_prediction=False)

--- a/codalab/apps/web/templates/web/my/detailed_results.html
+++ b/codalab/apps/web/templates/web/my/detailed_results.html
@@ -1,9 +1,11 @@
 {% extends 'base_account.html' %}
 {% load codalab_tags %}
 
-{% block head_title %}Detailed results of the participant {{user}}{% endblock head_title %}
-{% block page_title %}Detailed results of the participant {{user}}{% endblock page_title %}
+{% block head_title %}Detailed results of the participant {{ user }}{% endblock head_title %}
+{% block page_title %}Detailed results of the participant {{ user }}{% endblock page_title %}
 
-{% block content %}  
-    <iframe src={{filename|get_sas}} style="width:100%;min-height:100%;height:500px;"></iframe>      
+{% block content %}
+    <div align="center">
+        <iframe style="width: 75%; height: 100%;" src="{% url "competitions:my_competition_output" submission_id=submission.pk filetype='detailed_results.html' %}"></iframe>
+    </div>
 {% endblock %}

--- a/codalab/apps/web/views.py
+++ b/codalab/apps/web/views.py
@@ -1156,7 +1156,7 @@ class MyCompetitionSubmissionOutput(LoginRequiredMixin, View):
                 raise Http404()
         else:
             if (competition.creator != request.user and request.user not in competition.admins.all()) and \
-                request.user != submission.participant.user:
+                            request.user != submission.participant.user:
                 raise Http404()
 
         filetype = kwargs.get('filetype')
@@ -1207,7 +1207,12 @@ class MyCompetitionSubmissionDetailedResults(TemplateView):
 
     def get(self, request, *args, **kwargs):
         submission = models.CompetitionSubmission.objects.get(pk=kwargs.get('submission_id'))
-        context_dict = {'id': kwargs.get('submission_id'), 'user': submission.participant.user, 'filename':submission.detailed_results_file.name}
+
+        context_dict = {
+            'id': kwargs.get('submission_id'),
+            'user': submission.participant.user,
+            'submission': submission,
+        }
         return render_to_response('web/my/detailed_results.html', context_dict, RequestContext(request))
 
 


### PR DESCRIPTION
- [ ] Detailed results are now displayed properly in the `iframe`. Does not download, but displays.
   - Use existing view instead of sass URL