### PR TITLE
Clean Script tags from HTML

### DIFF
--- a/codalab/apps/web/forms.py
+++ b/codalab/apps/web/forms.py
@@ -14,6 +14,7 @@ from apps.queues.models import Queue
 from apps.web.models import PageContainer
 from apps.web.models import ContentCategory
 from apps.web.models import SubmissionScoreSet
+from apps.web.utils import clean_html_script
 
 User = get_user_model()
 
@@ -132,6 +133,9 @@ class PageForm(forms.ModelForm):
     def save(self, commit=True):
 
         instance = super(PageForm, self).save(commit=False)
+
+        if instance.html:
+            instance.html = clean_html_script(instance.html)
 
         if instance.pk is None:
             instance.codename = self.cleaned_data['label']

--- a/codalab/apps/web/models.py
+++ b/codalab/apps/web/models.py
@@ -46,7 +46,7 @@ from apps.forums.models import Forum
 from apps.coopetitions.models import DownloadRecord
 from apps.authenz.models import ClUser
 from apps.web.exceptions import ScoringException
-from apps.web.utils import PublicStorage, BundleStorage
+from apps.web.utils import PublicStorage, BundleStorage, clean_html_script
 from apps.teams.models import Team, get_user_team
 
 User = settings.AUTH_USER_MODEL
@@ -584,6 +584,8 @@ class Page(models.Model):
         ordering = ['category', 'rank']
 
     def save(self, *args, **kwargs):
+        if self.html:
+            self.html = clean_html_script(self.html)
         if self.defaults:
             if self.category != self.defaults.category:
                 raise Exception("Defaults category must match Item category")

--- a/codalab/apps/web/tests/test_html_clean.py
+++ b/codalab/apps/web/tests/test_html_clean.py
@@ -1,0 +1,22 @@
+from django.test import TestCase
+
+from apps.authenz.models import ClUser
+from apps.web.utils import clean_html_script
+
+
+class HTMLCleanTestCase(TestCase):
+
+    def setUp(self):
+        self.user = ClUser.objects.create_user(username="organizer", password="pass")
+
+    def test_script_tags_get_removed_from_html_content(self):
+        self.assertEquals(clean_html_script("<script></script>"), "")
+        self.assertEquals(clean_html_script("<script src=\"https://www.googleorsomething\"></script>"), "")
+        self.assertEquals(clean_html_script("<script src=\"https://www.googleorsomething\">There's some stuff in between here too </script>"), "")
+        self.assertEquals(clean_html_script("<script src=\"https://www.googleorsomething\">There's some stuff in between here too </script>There should be some stuff here."), "There should be some stuff here.")
+        self.assertEquals(clean_html_script("<b>A strong word</b>"), "<b>A strong word</b>")
+        self.assertEquals(clean_html_script({
+            'my_key': 1,
+            'my_value': "twenty_seven",
+        }), "{'my_value': 'twenty_seven', 'my_key': 1}")
+        self.assertEquals(clean_html_script(1), "1")

--- a/codalab/apps/web/tests/test_html_clean.py
+++ b/codalab/apps/web/tests/test_html_clean.py
@@ -5,10 +5,6 @@ from apps.web.utils import clean_html_script
 
 
 class HTMLCleanTestCase(TestCase):
-
-    def setUp(self):
-        self.user = ClUser.objects.create_user(username="organizer", password="pass")
-
     def test_script_tags_get_removed_from_html_content(self):
         self.assertEquals(clean_html_script("<script></script>"), "")
         self.assertEquals(clean_html_script("<script src=\"https://www.googleorsomething\"></script>"), "")

--- a/codalab/apps/web/tests/test_html_clean.py
+++ b/codalab/apps/web/tests/test_html_clean.py
@@ -7,6 +7,9 @@ from apps.web.utils import clean_html_script
 class HTMLCleanTestCase(TestCase):
     def test_script_tags_get_removed_from_html_content(self):
         self.assertEquals(clean_html_script("<script></script>"), "")
+        self.assertEquals(clean_html_script("""<
+        script src=\"https://www.googleorsomething\"
+        ></script>"""), "")
         self.assertEquals(clean_html_script("<script src=\"https://www.googleorsomething\"></script>"), "")
         self.assertEquals(clean_html_script("<script src=\"https://www.googleorsomething\">There's some stuff in between here too </script>"), "")
         self.assertEquals(clean_html_script("<script src=\"https://www.googleorsomething\">There's some stuff in between here too </script>There should be some stuff here."), "There should be some stuff here.")

--- a/codalab/apps/web/tests/test_html_clean.py
+++ b/codalab/apps/web/tests/test_html_clean.py
@@ -7,9 +7,6 @@ from apps.web.utils import clean_html_script
 class HTMLCleanTestCase(TestCase):
     def test_script_tags_get_removed_from_html_content(self):
         self.assertEquals(clean_html_script("<script></script>"), "")
-        self.assertEquals(clean_html_script("""<
-        script src=\"https://www.googleorsomething\"
-        ></script>"""), "")
         self.assertEquals(clean_html_script("<script src=\"https://www.googleorsomething\"></script>"), "")
         self.assertEquals(clean_html_script("<script src=\"https://www.googleorsomething\">There's some stuff in between here too </script>"), "")
         self.assertEquals(clean_html_script("<script src=\"https://www.googleorsomething\">There's some stuff in between here too </script>There should be some stuff here."), "There should be some stuff here.")

--- a/codalab/apps/web/utils.py
+++ b/codalab/apps/web/utils.py
@@ -24,6 +24,11 @@ else:
     PublicStorage = StorageClass()
 
 
+def clean_html_script(html_content):
+    # Finds <script and everything between /script>. No scripts for you.
+    return re.sub('(<script)(\s*?\S*?)*?(/script>)', "", html_content)
+
+
 def docker_image_clean(image_name):
     if not image_name:
         return ""

--- a/codalab/apps/web/utils.py
+++ b/codalab/apps/web/utils.py
@@ -26,7 +26,7 @@ else:
 
 def clean_html_script(html_content):
     # Finds <script and everything between /script>. No scripts for you.
-    return re.sub('(<script)(\s*?\S*?)*?(/script>)', "", html_content)
+    return re.sub('(<script)(\s*?\S*?)*?(/script>)', "", str(html_content))
 
 
 def docker_image_clean(image_name):


### PR DESCRIPTION
Adds a utility function that removes script tags and anything in-between on competition pages.

This gets called when
- We edit the competition from the form
- We upload raw HTML
- Attempt to save a Page object.