### PR TITLE
Update queryset for submission count

### DIFF
--- a/codalab/apps/web/models.py
+++ b/codalab/apps/web/models.py
@@ -1360,7 +1360,8 @@ class CompetitionSubmission(models.Model):
                         phase__competition=self.phase.competition,
                         participant=self.participant,
                         phase=self.phase,
-                        submitted_at__gte=datetime.date.today()
+                        submitted_at__gte=datetime.date.today(),
+                        status__codename=CompetitionSubmissionStatus.FINISHED,
                     ))
 
                     print 'Count is %s and maximum is %s' % (submissions_from_today_count, self.phase.max_submissions_per_day)


### PR DESCRIPTION
See #2042 

Updates the queryset for getting submissions from today, so that failed/re-ran submissions are not counted. 