### PR TITLE
Change label for `default_docker_image` in form

### DIFF
--- a/codalab/apps/web/forms.py
+++ b/codalab/apps/web/forms.py
@@ -90,6 +90,9 @@ class CompetitionPhaseForm(forms.ModelForm):
             'ingestion_program_organizer_dataset',
             'ingestion_program_docker_image',
         )
+        labels = {
+            'default_docker_image': "Default participant docker image"
+        }
         widgets = {
             'leaderboard_management_mode' : forms.Select(
                 attrs={'class': 'competition-editor-phase-leaderboard-mode'},


### PR DESCRIPTION
See issue #2043 

Adds the `labels` attribute to CompetitionPhaseForm to overwrite default docker image name's label. 

Currently changed to `Default participant docker image`

<img width="1143" alt="screen shot 2017-11-13 at 10 27 26 am" src="https://user-images.githubusercontent.com/28552312/32742193-8700ace4-c85d-11e7-9fe7-dca831650c2f.png">
