### PR TITLE
Remove Unwanted Headers for Sub Tabs

### DIFF
--- a/codalab/apps/web/templates/web/competitions/_get_starting_kit.html
+++ b/codalab/apps/web/templates/web/competitions/_get_starting_kit.html
@@ -1,6 +1,6 @@
 {% load codalab_tags %}
 
-<h1>Files</h1>
+{#<h1>Files</h1>#}
 {% if competition.has_starting_kit_or_public_data %}
     <table style="border: 1px solid rgba(0,0,0,0.3)" class="table table-responsive">
         <thead>
@@ -22,7 +22,8 @@
             {% if phase and phase.starting_kit_organizer_dataset %}
                 <tr>
                     <td>
-                        <a href="{% url 'datasets_download' dataset_key=phase.starting_kit_organizer_dataset.key %}" class="btn btn-primary phase-btn-{{ phase.color }}">{{phase.label}}</a>
+                        <a href="{% url 'datasets_download' dataset_key=phase.starting_kit_organizer_dataset.key %}"
+                           class="btn btn-primary phase-btn-{{ phase.color }}">{{ phase.label }}</a>
                     </td>
                     <td style="padding-top: 12px;">
                         {{ phase.get_starting_kit_size_mb|floatformat:3 }}
@@ -38,7 +39,8 @@
             {% if phase and phase.public_data_organizer_dataset %}
                 <tr>
                     <td>
-                        <a href="{% url 'datasets_download' dataset_key=phase.public_data_organizer_dataset.key %}" class="btn btn-primary phase-btn-{{ phase.color }}">{{phase.label}}</a>
+                        <a href="{% url 'datasets_download' dataset_key=phase.public_data_organizer_dataset.key %}"
+                           class="btn btn-primary phase-btn-{{ phase.color }}">{{ phase.label }}</a>
                     </td>
                     <td style="padding-top: 12px;">
                         {{ phase.get_public_data_size_mb|floatformat:3 }}

--- a/codalab/apps/web/templates/web/competitions/_innertabs.html
+++ b/codalab/apps/web/templates/web/competitions/_innertabs.html
@@ -16,7 +16,7 @@
                         {% include "web/competitions/_get_starting_kit.html" with competition=competition user=user %}
                     {% else %}
                         {% if content.codename == 'get_data' %}
-                            <h1>Get data</h1>
+{#                            <h1>Get data</h1>#}
                         {% endif %}
                         {{ content.processed_html|safe }}
                         {% if content.codename == "get_data" and competition.show_datasets_from_yaml %}

--- a/codalab/apps/web/templates/web/competitions/_submit_results.html
+++ b/codalab/apps/web/templates/web/competitions/_submit_results.html
@@ -1,6 +1,6 @@
 {% load codalab_tags %}
 
-<h1>Submit or view results</h1>
+{#<h1>Submit or view results</h1>#}
 
 <div id="submissions_phase_buttons">
   {% for phase in competition.phases.all %}


### PR DESCRIPTION
Removes the unwanted large headers from tabbed pages. 

<img width="1207" alt="screen shot 2017-11-16 at 11 46 12 am" src="https://user-images.githubusercontent.com/28552312/32912422-ddf57cd8-cac3-11e7-8d20-ae5fb021a261.png">
<img width="1218" alt="screen shot 2017-11-16 at 11 46 09 am" src="https://user-images.githubusercontent.com/28552312/32912423-de0a4708-cac3-11e7-9ec3-1ab168114413.png">
<img width="1228" alt="screen shot 2017-11-16 at 11 46 01 am" src="https://user-images.githubusercontent.com/28552312/32912424-de1ec0e8-cac3-11e7-93d0-6528bd9377d6.png">
