### PR TITLE
Fix Ordering On Posts

### DIFF
--- a/codalab/apps/forums/templates/forums/thread_detail.html
+++ b/codalab/apps/forums/templates/forums/thread_detail.html
@@ -4,7 +4,7 @@
 
 {% block content %}
     <h2 class="thread_title"> > {{ thread.title }}</h2>
-    {% for post in thread.posts.all %}
+    {% for post in ordered_posts %}
         {{ post.content|linebreaks }}
 
         <span class="posted_by">Posted by: {{ post.posted_by }} @ {{ post.date_created }}</span>

--- a/codalab/apps/forums/views.py
+++ b/codalab/apps/forums/views.py
@@ -4,7 +4,6 @@ from django.contrib.auth import get_user_model
 from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404
 from django.views.generic import DetailView, CreateView
-from django.views.generic.base import ContextMixin
 
 from apps.web.views import LoginRequiredMixin
 from .forms import PostForm, ThreadForm
@@ -89,7 +88,7 @@ class CreateThreadView(ForumBaseMixin, RedirectToThreadMixin, LoginRequiredMixin
         return HttpResponseRedirect(self.get_success_url())
 
 
-class ThreadDetailView(ForumBaseMixin, DetailView, ContextMixin):
+class ThreadDetailView(ForumBaseMixin, DetailView):
     """ View to read the details of a particular thread."""
     model = Thread
     template_name = "forums/thread_detail.html"

--- a/codalab/apps/forums/views.py
+++ b/codalab/apps/forums/views.py
@@ -4,6 +4,7 @@ from django.contrib.auth import get_user_model
 from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404
 from django.views.generic import DetailView, CreateView
+from django.views.generic.base import ContextMixin
 
 from apps.web.views import LoginRequiredMixin
 from .forms import PostForm, ThreadForm
@@ -88,9 +89,14 @@ class CreateThreadView(ForumBaseMixin, RedirectToThreadMixin, LoginRequiredMixin
         return HttpResponseRedirect(self.get_success_url())
 
 
-class ThreadDetailView(ForumBaseMixin, DetailView):
+class ThreadDetailView(ForumBaseMixin, DetailView, ContextMixin):
     """ View to read the details of a particular thread."""
     model = Thread
     template_name = "forums/thread_detail.html"
     pk_url_kwarg = 'thread_pk'
 
+    def get_context_data(self, **kwargs):
+        thread = self.object
+        context = super(ThreadDetailView, self).get_context_data(**kwargs)
+        context['ordered_posts'] = thread.posts.all().order_by('date_created')
+        return context


### PR DESCRIPTION
Addresses Issue #2064 

Explicitly sets get context for ThreadDetailView to order posts correctly. The bug seen in the referenced issue was due to no explicit ordering being set on the post objects.

Posts will now appear in the order they were posted.