### PR TITLE
Detailed Results Fixes

### DIFF
--- a/codalab/apps/web/templates/web/my/detailed_results.html
+++ b/codalab/apps/web/templates/web/my/detailed_results.html
@@ -3,9 +3,9 @@
 
 {% block head_title %}Detailed results of the participant {{ user }}{% endblock head_title %}
 {% block page_title %}Detailed results of the participant {{ user }}{% endblock page_title %}
-
 {% block content %}
+    <a href="{% url "competitions:view" pk=submission.phase.competition.pk %}" >Go Back to Competition Homepage</a>
     <div align="center">
-        <iframe style="width:100%; min-height:100%; height:500px;" src="{% url "competitions:my_competition_output" submission_id=submission.pk filetype='detailed_results.html' %}"></iframe>
+        <iframe style="width:100%; height:90vh;" src="{% url "competitions:my_competition_output" submission_id=submission.pk filetype='detailed_results.html' %}"></iframe>
     </div>
 {% endblock %}

--- a/codalab/apps/web/tests/test_submission_download.py
+++ b/codalab/apps/web/tests/test_submission_download.py
@@ -80,20 +80,20 @@ class CompetitionSubmissionDownloadTests(TestCase):
         resp = self.client.get(self.url)
         self.assertEquals(resp.content, self.submission_1.stdout_file.read())
 
-    def test_submission_download_public_requires_participation_access(self):
-        self.submission_1.is_public = True
-        self.submission_1.save()
-        self.competition.has_registration = True
-        self.competition.save()
-
-        self.client.login(username="other", password="pass")
-        resp = self.client.get(self.url)
-        self.assertEquals(resp.status_code, 404)
-        self.client.logout()
-
-        self.client.login(username="other_participant", password="pass")
-        resp = self.client.get(self.url)
-        self.assertEquals(resp.status_code, 200)
+    # def test_submission_download_public_requires_participation_access(self):
+    #     self.submission_1.is_public = True
+    #     self.submission_1.save()
+    #     self.competition.has_registration = True
+    #     self.competition.save()
+    #
+    #     self.client.login(username="other", password="pass")
+    #     resp = self.client.get(self.url)
+    #     self.assertEquals(resp.status_code, 404)
+    #     self.client.logout()
+    #
+    #     self.client.login(username="other_participant", password="pass")
+    #     resp = self.client.get(self.url)
+    #     self.assertEquals(resp.status_code, 200)
 
     def test_submission_download_public_without_registration_allows_access(self):
         self.competition.has_registration = False

--- a/codalab/apps/web/views.py
+++ b/codalab/apps/web/views.py
@@ -1151,10 +1151,7 @@ class MyCompetitionSubmissionOutput(LoginRequiredMixin, View):
         competition = submission.phase.competition
 
         # Check competition admin permissions or user permissions
-        if submission.is_public:
-            if competition.has_registration and not competition.participants.filter(user=request.user).exists():
-                raise Http404()
-        else:
+        if not submission.is_public:
             if (competition.creator != request.user and request.user not in competition.admins.all()) and \
                             request.user != submission.participant.user:
                 raise Http404()


### PR DESCRIPTION
Addresses issue #2055 

- Remove extra permission checks:
    * If your submission is public, everyone can view it
    * Else, only competition owners, the submission owner, or admins of the competition can view.
- Add link back to competition from detailed results
- Force the IFRAME's height to 90% of view height

Still need to address the text formatting vs HTML formatting of detailed results.