### PR TITLE
Make Submission Results Table responsive

### DIFF
--- a/codalab/apps/web/templates/web/competitions/_submit_results_page.html
+++ b/codalab/apps/web/templates/web/competitions/_submit_results_page.html
@@ -85,8 +85,9 @@
         <input type="hidden" id="phasestate" value="0" />
     {% endif %}
         <input type="hidden" id="submission_phase_id" class="form-control" value="{{ phase.id }}">
-        <table class="table resultsTable dataTable table-striped table-bordered" id="user_results">
-            <thead>
+        <div class="table-responsive">
+            <table class="table resultsTable dataTable table-striped table-bordered" id="user_results">
+                <thead>
                 <tr>
                     <th>#</th>
                     <th>Score</th>
@@ -96,49 +97,51 @@
                     <th>Status</th>
                     <th class="text-center"><span class="glyphicon glyphicon-ok"></span></th>
                 </tr>
-            </thead>
-            <tbody>
-            {% if submission_info_list|length_is:"0" %}
-                <tr class="noData">
-                    <td class="tdDetails" colspan="7">No data available in table</td>
-                </tr>
-            {% else %}
-                {% for submission_info in submission_info_list %}
-                    <tr id="{{ submission_info.id }}"
-                        {% if submission_info.exception_details %}
-                            data-exception="{{ submission_info.exception_details|escape }}"
-                        {% endif %}
-                        data-score="{{ submission_info.score|default_if_none:""|escape }}"
-                        data-description="{{ submission_info.description|default_if_none:""|escape }}"
-                        data-method-name="{{ submission_info.method_name|default_if_none:""|escape }}"
-                        data-method-description="{{ submission_info.method_description|default_if_none:""|escape }}"
-                        data-project-url="{{ submission_info.project_url|default_if_none:""|escape }}"
-                        data-publication-url="{{ submission_info.publication_url|default_if_none:""|escape }}"
-                        data-team-name="{{ submission_info.team_name|default_if_none:""|escape }}"
-                        data-organization-or-affiliation="{{ submission_info.organization_or_affiliation|default_if_none:""|escape }}"
-                        data-bibtex="{{ submission_info.bibtex|default_if_none:""|escape }}"
-                        data-is-public="{% if submission_info.is_public %}True{% endif %}">
-                        {% if submission_info.is_finished %}
-                            <input type="hidden" name="state" value='1' />
-                        {% else %}
-                            <input type="hidden" name="state" value='0' />
-                        {% endif %}
-                        <td>{{ forloop.counter }}</td>
-                        <td>{{ submission_info.score }}</td>
-                        <td>{{ submission_info.filename }}</td>
-                        <td>{{ submission_info.submitted_at|date:"m/d/Y H:i:s" }}</td>
-                        <td class="statusName">{{ submission_info.status_name }}</td>
-                        {% if submission_info.is_in_leaderboard %}
-                            <td class="status submitted text-center"><span class="glyphicon glyphicon-ok text-success"></span></td>
-                        {% else %}
-                            <td class="status not_submitted text-center"></td>
-                        {% endif %}
-                        <td class="text-center"><span class="glyphicon glyphicon-plus"></span></td>
+                </thead>
+                <tbody>
+                {% if submission_info_list|length_is:"0" %}
+                    <tr class="noData">
+                        <td class="tdDetails" colspan="7">No data available in table</td>
                     </tr>
-                {% endfor %}
-            {% endif %}
-            </tbody>
-        </table>
+                {% else %}
+                    {% for submission_info in submission_info_list %}
+                        <tr id="{{ submission_info.id }}"
+                                {% if submission_info.exception_details %}
+                            data-exception="{{ submission_info.exception_details|escape }}"
+                                {% endif %}
+                            data-score="{{ submission_info.score|default_if_none:""|escape }}"
+                            data-description="{{ submission_info.description|default_if_none:""|escape }}"
+                            data-method-name="{{ submission_info.method_name|default_if_none:""|escape }}"
+                            data-method-description="{{ submission_info.method_description|default_if_none:""|escape }}"
+                            data-project-url="{{ submission_info.project_url|default_if_none:""|escape }}"
+                            data-publication-url="{{ submission_info.publication_url|default_if_none:""|escape }}"
+                            data-team-name="{{ submission_info.team_name|default_if_none:""|escape }}"
+                            data-organization-or-affiliation="{{ submission_info.organization_or_affiliation|default_if_none:""|escape }}"
+                            data-bibtex="{{ submission_info.bibtex|default_if_none:""|escape }}"
+                            data-is-public="{% if submission_info.is_public %}True{% endif %}">
+                            {% if submission_info.is_finished %}
+                                <input type="hidden" name="state" value='1'/>
+                            {% else %}
+                                <input type="hidden" name="state" value='0'/>
+                            {% endif %}
+                            <td>{{ forloop.counter }}</td>
+                            <td>{{ submission_info.score }}</td>
+                            <td>{{ submission_info.filename }}</td>
+                            <td>{{ submission_info.submitted_at|date:"m/d/Y H:i:s" }}</td>
+                            <td class="statusName">{{ submission_info.status_name }}</td>
+                            {% if submission_info.is_in_leaderboard %}
+                                <td class="status submitted text-center"><span
+                                        class="glyphicon glyphicon-ok text-success"></span></td>
+                            {% else %}
+                                <td class="status not_submitted text-center"></td>
+                            {% endif %}
+                            <td class="text-center"><span class="glyphicon glyphicon-plus"></span></td>
+                        </tr>
+                    {% endfor %}
+                {% endif %}
+                </tbody>
+            </table>
+        </div>
     </div>
 {% include "web/common/_submission_details_template.html" %}
 {% endif %}


### PR DESCRIPTION
Surrounds the submission result table with a `table-responsive` class div, allowing it to re-size or turn scrollable when needed.

Should fix issue #2070 