### PR TITLE
Bad Scores UI Change and Outer-Curve References

### DIFF
--- a/codalab/apps/web/templates/emails/base_email.html
+++ b/codalab/apps/web/templates/emails/base_email.html
@@ -77,8 +77,6 @@
 
 <div id="footer">
     <p><a href="http://{{ site.domain }}{% url "user_settings" %}">Unsubscribe or manage notification settings</a> | <a href="http://codalab.github.io/codalab/notices.html">Privacy policy</a></p>
-    <p>The Outercurve Foundation <br>
-    401 Edgewater Place, Suite 600, Wakefield, MA 01880</p>
 </div>
 </body>
 </html>

--- a/codalab/apps/web/templates/emails/base_email.txt
+++ b/codalab/apps/web/templates/emails/base_email.txt
@@ -15,6 +15,3 @@ CodaLab Team
 Unsubscribe or manage notification settings -> http://{{ site.domain }}{% url 'user_settings' %}
 
 Privacy policy -> http://codalab.github.io/codalab/notices.html
-
-The Outercurve Foundation
-401 Edgewater Place, Suite 600, Wakefield, MA 01880

--- a/codalab/apps/web/templates/web/competitions/_results_page.html
+++ b/codalab/apps/web/templates/web/competitions/_results_page.html
@@ -25,31 +25,6 @@
         <p><b>Max submissions per day: </b> {{ phase.max_submissions_per_day }}</p>
         <p><b>Max submissions total: </b> {{ phase.max_submissions }}</p>
     </div>
-    <!-- Where to put the warnings for bad scores if we're showing them on results as well -->
-    {% if scoring_exception and bad_scores %}
-        <div class="alert alert-danger">
-            <p>{{ scoring_exception }}</p>
-            <strong>Bad Scores:</strong>
-            <table class="table table-bordered table-responsive">
-                <thead>
-                <tr>
-                    <th>Rank:</th>
-                    <th>Value:</th>
-                    <th>Column Name:</th>
-                </tr>
-                </thead>
-                <tbody>
-                {% for bad_score in bad_scores %}
-                    <tr>
-                        <td>{{ bad_score.rnk }}</td>
-                        <td>{{ bad_score.val }}</td>
-                        <td>{{ bad_score.name }}</td>
-                    </tr>
-                {% endfor %}
-                </tbody>
-            </table>
-        </div>
-    {% endif %}
 
     {% if groups|length > 0 %}
         <a class="icon-excel btn btn-default" href="/competitions/{{phase.competition.id}}/results/{{phase.id}}/data">Download CSV</a>

--- a/codalab/apps/web/templates/web/my/submissions.html
+++ b/codalab/apps/web/templates/web/my/submissions.html
@@ -29,10 +29,12 @@
         </div>
 
         {% if scoring_exception and bad_scores %}
-            <div class="alert alert-danger">
+            <button class="btn btn-danger" data-toggle="collapse" data-target="#demo">Show Leaderboard Debug</button>
+
+            <div id="demo" class="collapse well">
                 <p>{{ scoring_exception }}</p>
                 <strong>Bad Scores:</strong>
-                <table class="table table-bordered table-responsive">
+                <table class="table table-bordered table-responsive bg-warning">
                     <thead>
                     <tr>
                         <th>Rank:</th>
@@ -51,6 +53,7 @@
                     </tbody>
                 </table>
             </div>
+            <br>
         {% endif %}
 
         <a href="{% url "competitions:competition_submissions_metadata" competition_id=competition.pk phase_id=selected_phase.id %}">View
@@ -83,8 +86,10 @@
                     {% for column in columns %}
                         <th>
                             <a href="?phase={{ selected_phase_id }}&order=
+
                                     {{ column.name }}{% if direction == 'asc' and order == column.name %}&direction=desc{% endif %}">
                                 {{ column.label }} <span class="glyphicon
+
                                     {% if order == column.name %}{% if direction == 'asc' %}glyphicon-arrow-down{% else %}glyphicon-arrow-up{% endif %}{% endif %} pull-right"></span>
                             </a>
                         </th>

--- a/codalab/apps/web/templates/web/my/submissions.html
+++ b/codalab/apps/web/templates/web/my/submissions.html
@@ -29,9 +29,9 @@
         </div>
 
         {% if scoring_exception and bad_scores %}
-            <button class="btn btn-danger" data-toggle="collapse" data-target="#demo">Show Leaderboard Debug</button>
+            <button class="btn btn-danger" data-toggle="collapse" data-target="#leaderboard-debug">Show Leaderboard Debug</button>
 
-            <div id="demo" class="collapse well">
+            <div id="leaderboard-debug" class="collapse well">
                 <p>{{ scoring_exception }}</p>
                 <strong>Bad Scores:</strong>
                 <table class="table table-bordered table-responsive bg-warning">

--- a/codalab/apps/web/views.py
+++ b/codalab/apps/web/views.py
@@ -747,14 +747,6 @@ class CompetitionResultsPage(TemplateView):
             context['phase'] = phase
             context['groups'] = phase.scores()
 
-            bad_score_count, bad_scores = check_bad_scores(context['groups'])
-            if bad_score_count > 0:
-                context['scoring_exception'] = "ERROR: Improperly configured leaderboard or scoring program. Some " \
-                                               "scores have NaN! Please check your leaderboard configuration and" \
-                                               " scoring program for the competition!"
-                context['bad_scores'] = bad_scores
-                context['bad_score_count'] = bad_score_count
-
             for group in context['groups']:
                 for _, scoredata in group['scores']:
                     sub = models.CompetitionSubmission.objects.get(pk=scoredata['id'])


### PR DESCRIPTION
Addresses: 
 - [ ] #2092 
 - [ ] #2090 

- Removes outer-curve information and references from email templates
- Removes bad scores debug info from public submissions page
- Changes bad score debug info to use drop down button on admin `submissions` page. Only appears if there is debug info. 

#### Media Demo:
---

<img width="227" alt="screen shot 2017-11-28 at 3 30 23 pm" src="https://user-images.githubusercontent.com/28552312/33350479-dea8752e-d453-11e7-8d86-45155a2a4522.png">
<img width="1159" alt="screen shot 2017-11-28 at 3 27 59 pm" src="https://user-images.githubusercontent.com/28552312/33350504-fbd86b04-d453-11e7-9ef3-7aed9e606020.png">
<img width="1177" alt="screen shot 2017-11-28 at 3 27 54 pm" src="https://user-images.githubusercontent.com/28552312/33350494-e7f2b90a-d453-11e7-85da-33af3d381ed8.png">

