### PR TITLE
Make Tables Responsive

### DIFF
--- a/codalab/apps/web/templates/web/competitions/_submit_results_page.html
+++ b/codalab/apps/web/templates/web/competitions/_submit_results_page.html
@@ -85,63 +85,61 @@
         <input type="hidden" id="phasestate" value="0" />
     {% endif %}
         <input type="hidden" id="submission_phase_id" class="form-control" value="{{ phase.id }}">
-        <div class="table-responsive">
-            <table class="table resultsTable dataTable table-striped table-bordered" id="user_results">
-                <thead>
-                <tr>
-                    <th>#</th>
-                    <th>Score</th>
-                    <th>Filename</th>
-                    <th>Score</th>
-                    <th>Submission date</th>
-                    <th>Status</th>
-                    <th class="text-center"><span class="glyphicon glyphicon-ok"></span></th>
+        <table style="overflow-x:auto; display: block !important;" class="table table-responsive resultsTable table-striped table-bordered" id="user_results">
+            <thead>
+            <tr>
+                <th>#</th>
+                <th>Score</th>
+                <th>Filename</th>
+                <th>Score</th>
+                <th>Submission date</th>
+                <th>Status</th>
+                <th class="text-center"><span class="glyphicon glyphicon-ok"></span></th>
+            </tr>
+            </thead>
+            <tbody>
+            {% if submission_info_list|length_is:"0" %}
+                <tr class="noData">
+                    <td class="tdDetails" colspan="7">No data available in table</td>
                 </tr>
-                </thead>
-                <tbody>
-                {% if submission_info_list|length_is:"0" %}
-                    <tr class="noData">
-                        <td class="tdDetails" colspan="7">No data available in table</td>
+            {% else %}
+                {% for submission_info in submission_info_list %}
+                    <tr id="{{ submission_info.id }}"
+                            {% if submission_info.exception_details %}
+                        data-exception="{{ submission_info.exception_details|escape }}"
+                            {% endif %}
+                        data-score="{{ submission_info.score|default_if_none:""|escape }}"
+                        data-description="{{ submission_info.description|default_if_none:""|escape }}"
+                        data-method-name="{{ submission_info.method_name|default_if_none:""|escape }}"
+                        data-method-description="{{ submission_info.method_description|default_if_none:""|escape }}"
+                        data-project-url="{{ submission_info.project_url|default_if_none:""|escape }}"
+                        data-publication-url="{{ submission_info.publication_url|default_if_none:""|escape }}"
+                        data-team-name="{{ submission_info.team_name|default_if_none:""|escape }}"
+                        data-organization-or-affiliation="{{ submission_info.organization_or_affiliation|default_if_none:""|escape }}"
+                        data-bibtex="{{ submission_info.bibtex|default_if_none:""|escape }}"
+                        data-is-public="{% if submission_info.is_public %}True{% endif %}">
+                        {% if submission_info.is_finished %}
+                            <input type="hidden" name="state" value='1'/>
+                        {% else %}
+                            <input type="hidden" name="state" value='0'/>
+                        {% endif %}
+                        <td>{{ forloop.counter }}</td>
+                        <td>{{ submission_info.score }}</td>
+                        <td>{{ submission_info.filename }}</td>
+                        <td>{{ submission_info.submitted_at|date:"m/d/Y H:i:s" }}</td>
+                        <td class="statusName">{{ submission_info.status_name }}</td>
+                        {% if submission_info.is_in_leaderboard %}
+                            <td class="status submitted text-center"><span
+                                    class="glyphicon glyphicon-ok text-success"></span></td>
+                        {% else %}
+                            <td class="status not_submitted text-center"></td>
+                        {% endif %}
+                        <td class="text-center"><span class="glyphicon glyphicon-plus"></span></td>
                     </tr>
-                {% else %}
-                    {% for submission_info in submission_info_list %}
-                        <tr id="{{ submission_info.id }}"
-                                {% if submission_info.exception_details %}
-                            data-exception="{{ submission_info.exception_details|escape }}"
-                                {% endif %}
-                            data-score="{{ submission_info.score|default_if_none:""|escape }}"
-                            data-description="{{ submission_info.description|default_if_none:""|escape }}"
-                            data-method-name="{{ submission_info.method_name|default_if_none:""|escape }}"
-                            data-method-description="{{ submission_info.method_description|default_if_none:""|escape }}"
-                            data-project-url="{{ submission_info.project_url|default_if_none:""|escape }}"
-                            data-publication-url="{{ submission_info.publication_url|default_if_none:""|escape }}"
-                            data-team-name="{{ submission_info.team_name|default_if_none:""|escape }}"
-                            data-organization-or-affiliation="{{ submission_info.organization_or_affiliation|default_if_none:""|escape }}"
-                            data-bibtex="{{ submission_info.bibtex|default_if_none:""|escape }}"
-                            data-is-public="{% if submission_info.is_public %}True{% endif %}">
-                            {% if submission_info.is_finished %}
-                                <input type="hidden" name="state" value='1'/>
-                            {% else %}
-                                <input type="hidden" name="state" value='0'/>
-                            {% endif %}
-                            <td>{{ forloop.counter }}</td>
-                            <td>{{ submission_info.score }}</td>
-                            <td>{{ submission_info.filename }}</td>
-                            <td>{{ submission_info.submitted_at|date:"m/d/Y H:i:s" }}</td>
-                            <td class="statusName">{{ submission_info.status_name }}</td>
-                            {% if submission_info.is_in_leaderboard %}
-                                <td class="status submitted text-center"><span
-                                        class="glyphicon glyphicon-ok text-success"></span></td>
-                            {% else %}
-                                <td class="status not_submitted text-center"></td>
-                            {% endif %}
-                            <td class="text-center"><span class="glyphicon glyphicon-plus"></span></td>
-                        </tr>
-                    {% endfor %}
-                {% endif %}
-                </tbody>
-            </table>
-        </div>
+                {% endfor %}
+            {% endif %}
+            </tbody>
+        </table>
     </div>
 {% include "web/common/_submission_details_template.html" %}
 {% endif %}

--- a/codalab/apps/web/templates/web/my/submissions.html
+++ b/codalab/apps/web/templates/web/my/submissions.html
@@ -79,7 +79,7 @@
         {% if not submission_info_list %}
             <p>There are no submissions.</p>
         {% else %}
-            <table class="resultsTable dataTable">
+            <table style="overflow-x:auto; display: block" class="table table-responsive resultsTable">
                 <thead>
                 <tr>
                     <th>#</th>


### PR DESCRIPTION
Tables were still failing to act responsive in all cases.

- Removes the `DataTable` classes from tables, as this is from JQuery and forces table width to 100%. 

- Add inline styling for now to force the correct behavior with boostrap's `table-responsive` class.