### PR TITLE
Force scores to always return list format

### DIFF
--- a/codalab/apps/web/models.py
+++ b/codalab/apps/web/models.py
@@ -1172,6 +1172,10 @@ class CompetitionPhase(models.Model):
                     del result['scoredefs']
                 except KeyError:
                     pass
+
+        for group in results:
+            if type(group['scores']) == dict:
+                group['scores'] = group['scores'].items()
         return results
 
 


### PR DESCRIPTION
Addresses an issue with the leaderboard, where when editing an active competition, or in some other unknown cause, the competition fails to display overall, or the results page fails to display, or the submissions page fails to display. 

The fix forces the `scores` method on phase, to always return in the same format. 

Tested with broken competitions locally, and is working. Unaffected competitions should remain unchanged.