### PR TITLE
Health page updates

### DIFF
--- a/codalab/apps/health/templates/health/_job_table.html
+++ b/codalab/apps/health/templates/health/_job_table.html
@@ -1,0 +1,24 @@
+<table class="table table-bordered table-responsive">
+    <thead>
+    <tr>
+        <th>ID</th>
+        <th>Status</th>
+        <th>Created</th>
+        <th>Type</th>
+        <th>Info</th>
+        <th>Updated</th>
+    </tr>
+    </thead>
+    <tbody>
+    {% for job in jobs_list %}
+        <tr>
+            <td>{{ job.pk }}</td>
+            <td>{{ job.get_status_code_name }}</td>
+            <td>{{ job.created }}</td>
+            <td>{{ job.task_type }}</td>
+            <td>{{ job.task_info_json }}</td>
+            <td>{{ job.updated }}</td>
+        </tr>
+    {% endfor %}
+    </tbody>
+</table>

--- a/codalab/apps/health/templates/health/health.html
+++ b/codalab/apps/health/templates/health/health.html
@@ -6,7 +6,9 @@
 {% block content %}
     <div class="row">
         <p class="title" data-section-title width="100%" height="100%">
-            <h1><a href="#health">Health</a></h1>
+        <h1>
+            <a href="#health">Health</a>
+        </h1>
         </p>
         <div class="content" data-slug="health" data-section-content>
             <div class="row">
@@ -43,8 +45,233 @@
                 </div>
             </div>
         </div>
+
+        <hr>
+
+        <div align="center">
+            <button class="btn btn-lg btn-primary" data-toggle="collapse" data-target="#jobs_from_today">
+                Jobs from today
+            </button>
+
+            <div id="jobs_from_today" class="collapse well">
+                <strong>All jobs from today:</strong>
+                <table class="table table-bordered table-responsive">
+                    <thead>
+                    <tr>
+                        <th>ID</th>
+                        <th>Status</th>
+                        <th>Created</th>
+                        <th>Updated</th>
+                        <th>Info</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    {% for job in jobs_today %}
+                        <tr>
+                            <td>{{ job.pk }}</td>
+                            <td>{{ job.status }}</td>
+                            <td>{{ job.created }}</td>
+                            <td>{{ job.updated }}</td>
+                            <td>{{ job.task_info_json }}</td>
+                        </tr>
+                    {% endfor %}
+                    </tbody>
+                </table>
+
+                <strong>Failed jobs from today:</strong>
+                <table class="table table-bordered table-responsive bg-danger">
+                    <thead>
+                    <tr>
+                        <th>ID</th>
+                        <th>Status</th>
+                        <th>Created</th>
+                        <th>Updated</th>
+                        <th>Info</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    {% for job in jobs_today_failed %}
+                        <tr>
+                            <td>{{ job.pk }}</td>
+                            <td>{{ job.status }}</td>
+                            <td>{{ job.created }}</td>
+                            <td>{{ job.updated }}</td>
+                            <td>{{ job.task_info_json }}</td>
+                        </tr>
+                    {% endfor %}
+                    </tbody>
+                </table>
+
+                <strong>Finished jobs from today:</strong>
+                <table class="table table-bordered table-responsive bg-success">
+                    <thead>
+                    <tr>
+                        <th>ID</th>
+                        <th>Status</th>
+                        <th>Created</th>
+                        <th>Updated</th>
+                        <th>Info</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    {% for job in jobs_today_finished %}
+                        <tr>
+                            <td>{{ job.pk }}</td>
+                            <td>{{ job.status }}</td>
+                            <td>{{ job.created }}</td>
+                            <td>{{ job.updated }}</td>
+                            <td>{{ job.task_info_json }}</td>
+                        </tr>
+                    {% endfor %}
+                    </tbody>
+                </table>
+
+                <strong>Pending jobs from today:</strong>
+                <table class="table table-bordered table-responsive bg-warning">
+                    <thead>
+                    <tr>
+                        <th>ID</th>
+                        <th>Status</th>
+                        <th>Created</th>
+                        <th>Updated</th>
+                        <th>Info</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    {% for job in jobs_today_pending %}
+                        <tr>
+                            <td>{{ job.pk }}</td>
+                            <td>{{ job.status }}</td>
+                            <td>{{ job.created }}</td>
+                            <td>{{ job.updated }}</td>
+                            <td>{{ job.task_info_json }}</td>
+                        </tr>
+                    {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+            <br>
+        </div>
+
+        <hr>
+
+        <div align="center">
+            <button class="btn btn-lg btn-primary" data-toggle="collapse" data-target="#jobs_last_fifty">
+                Last 50 Jobs
+            </button>
+
+            <div id="jobs_last_fifty" class="collapse well">
+                <strong>Last 50 Jobs by creation date</strong>
+                <table class="table table-striped table-bordered table-responsive">
+                    <thead>
+                    <tr>
+                        <th>ID</th>
+                        <th>Status</th>
+                        <th>Created</th>
+                        <th>Updated</th>
+                        <th>Info</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    {% for job in jobs_last_fifty %}
+                        <tr>
+                            <td>{{ job.pk }}</td>
+                            <td>{{ job.status }}</td>
+                            <td>{{ job.created }}</td>
+                            <td>{{ job.updated }}</td>
+                            <td>{{ job.task_info_json }}</td>
+                        </tr>
+                    {% endfor %}
+                    </tbody>
+                </table>
+
+                <strong>Last 50 Jobs by update date</strong>
+                <table class="table table-striped table-bordered table-responsive">
+                    <thead>
+                    <tr>
+                        <th>ID</th>
+                        <th>Status</th>
+                        <th>Created</th>
+                        <th>Updated</th>
+                        <th>Info</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    {% for job in jobs_last_fifty_updated %}
+                        <tr>
+                            <td>{{ job.pk }}</td>
+                            <td>{{ job.status }}</td>
+                            <td>{{ job.created }}</td>
+                            <td>{{ job.updated }}</td>
+                            <td>{{ job.task_info_json }}</td>
+                        </tr>
+                    {% endfor %}
+                    </tbody>
+                </table>
+
+                <strong>Last 50 failed jobs by update date</strong>
+                <table class="table table-bordered table-striped table-responsive">
+                    <thead>
+                    <tr>
+                        <th>ID</th>
+                        <th>Status</th>
+                        <th>Created</th>
+                        <th>Updated</th>
+                        <th>Info</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    {% for job in jobs_last_fifty_failed %}
+                        <tr class="bg-danger">
+                            <td>{{ job.pk }}</td>
+                            <td>{{ job.status }}</td>
+                            <td>{{ job.created }}</td>
+                            <td>{{ job.updated }}</td>
+                            <td>{{ job.task_info_json }}</td>
+                        </tr>
+                    {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+
+        <hr>
+
+        <div align="center">
+            <button class="btn btn-lg btn-danger" data-toggle="collapse" data-target="#jobs_pending">
+                Stuck Pending Jobs
+            </button>
+
+            <div id="jobs_pending" class="collapse well">
+                <strong>Pending jobs older than one day</strong>
+                <i>These jobs are older than one day, and are still on the pending status.</i>
+                <table class="table table-striped table-bordered table-responsive">
+                    <thead>
+                    <tr>
+                        <th>ID</th>
+                        <th>Status</th>
+                        <th>Created</th>
+                        <th>Updated</th>
+                        <th>Info</th>
+                    </tr>
+                    </thead>
+                    <tbody class="bg-warning">
+                    {% for job in jobs_pending_stuck %}
+                        <tr>
+                            <td>{{ job.pk }}</td>
+                            <td>{{ job.status }}</td>
+                            <td>{{ job.created }}</td>
+                            <td>{{ job.updated }}</td>
+                            <td>{{ job.task_info_json }}</td>
+                        </tr>
+                    {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+
         <p class="title" data-section-title width="100%" height="100%">
-            <h1><a href="#settings">Settings</a></h1>
+        <h1><a href="#settings">Settings</a></h1>
         </p>
         <div class="content" data-slug="settings" data-section-content>
             Stuck job threshold<br>
@@ -53,8 +280,10 @@
             <br><br>
 
             List of emails to notify on error, separated by commas<br>
-            <label for="email_settings_textarea">eg: eric.carmichael@tivix.com, francis@tivix.com, flavio.zhingri@tivix.com</label><br>
-            <textarea id="email_settings_textarea" name="email_settings_textarea" style="resize:vertical; display: block;">{{ alert_emails }}</textarea><br>
+            <label for="email_settings_textarea">eg: eric.carmichael@tivix.com, francis@tivix.com,
+                flavio.zhingri@tivix.com</label><br>
+            <textarea id="email_settings_textarea" name="email_settings_textarea"
+                      style="resize:vertical; display: block;">{{ alert_emails }}</textarea><br>
             <input id="email_settings_submit_button" type="submit" class="button" value="Save">
 
             <div id="email_settings_submit_status"></div>
@@ -63,38 +292,41 @@
     </div>
 {% endblock %}
 <script>
-{% block js %}
-    $(function () {
-        $("#email_settings_submit_button").click(function(){
-            $.post("{% url "health_status_email_settings" %}", {"alert_threshold": $("#alert_threshold").val(), "emails": $("#email_settings_textarea").val()})
-                .success(function() {
-                    $("#email_settings_submit_status").html("<p style='color: #258033;'>Settings saved successfully!</p>");
+    {% block js %}
+        $(function () {
+            $("#email_settings_submit_button").click(function () {
+                $.post("{% url "health_status_email_settings" %}", {
+                    "alert_threshold": $("#alert_threshold").val(),
+                    "emails": $("#email_settings_textarea").val()
                 })
-                .error(function() {
-                    alert("Couldn't save settings, something went wrong");
-                });
-        });
-
-        $('.meter').each(function() {
-            var gauge = new Gauge(this).setOptions({
-                colorStart: '#ffffff',   // Colors
-                colorStop: '#8FC0DA',    // just experiment with them
-                strokeColor: '#E0E0E0',  // to see which ones work best for you
-                generateGradient: false,
-                percentColors: [
-                    [ 0.0, "#5CB85C" ],
-                    [ 0.40, "#5CB85C" ],
-                    //[ 0.41, "#ccc" ],
-                    [ 0.5, "#5BC0DE" ],
-                    [ 0.8, "#F0AD4E" ],
-                    [ 1.0, "#D9534F" ]
-                ]
+                    .success(function () {
+                        $("#email_settings_submit_status").html("<p style='color: #258033;'>Settings saved successfully!</p>");
+                    })
+                    .error(function () {
+                        alert("Couldn't save settings, something went wrong");
+                    });
             });
-            gauge.maxValue = $(this).attr('data-max');
-            gauge.set(parseFloat($(this).attr('data-value')));
+
+            $('.meter').each(function () {
+                var gauge = new Gauge(this).setOptions({
+                    colorStart: '#ffffff',   // Colors
+                    colorStop: '#8FC0DA',    // just experiment with them
+                    strokeColor: '#E0E0E0',  // to see which ones work best for you
+                    generateGradient: false,
+                    percentColors: [
+                        [0.0, "#5CB85C"],
+                        [0.40, "#5CB85C"],
+                        //[ 0.41, "#ccc" ],
+                        [0.5, "#5BC0DE"],
+                        [0.8, "#F0AD4E"],
+                        [1.0, "#D9534F"]
+                    ]
+                });
+                gauge.maxValue = $(this).attr('data-max');
+                gauge.set(parseFloat($(this).attr('data-value')));
+            });
         });
-    });
-{% endblock %}
+    {% endblock %}
 </script>
 {% block extra_scripts %}
     <script src="{{ STATIC_URL }}js/vendor/gauge.min.js"></script>

--- a/codalab/apps/health/templates/health/health.html
+++ b/codalab/apps/health/templates/health/health.html
@@ -49,9 +49,24 @@
         <hr>
 
         <div align="center">
-            <button class="btn btn-lg btn-primary" data-toggle="collapse" data-target="#jobs_from_today">
-                Jobs from today
-            </button>
+
+            <div class="btn-group" role="group" aria-label="Button Group">
+
+                <button class="btn btn-lg btn-primary" data-toggle="collapse" data-target="#jobs_from_today">
+                    Jobs from today ({{ jobs_today_count }})
+                </button>
+
+                <button class="btn btn-lg btn-primary" data-toggle="collapse" data-target="#jobs_last_fifty">
+                    Last 50 Jobs
+                </button>
+
+                <button class="btn btn-lg btn-danger" data-toggle="collapse" data-target="#jobs_pending">
+                    Stuck Jobs ({{ jobs_all_stuck_count }})
+                </button>
+
+            </div>
+
+            <!-- Today's jobs collapsable well-->
 
             <div id="jobs_from_today" class="collapse well">
                 <strong>All jobs from today:</strong>
@@ -61,18 +76,20 @@
                         <th>ID</th>
                         <th>Status</th>
                         <th>Created</th>
-                        <th>Updated</th>
+                        <th>Type</th>
                         <th>Info</th>
+                        <th>Updated</th>
                     </tr>
                     </thead>
                     <tbody>
                     {% for job in jobs_today %}
                         <tr>
                             <td>{{ job.pk }}</td>
-                            <td>{{ job.status }}</td>
+                            <td>{{ job.get_status_code_name }}</td>
                             <td>{{ job.created }}</td>
-                            <td>{{ job.updated }}</td>
+                            <td>{{ job.task_type }}</td>
                             <td>{{ job.task_info_json }}</td>
+                            <td>{{ job.updated }}</td>
                         </tr>
                     {% endfor %}
                     </tbody>
@@ -85,18 +102,20 @@
                         <th>ID</th>
                         <th>Status</th>
                         <th>Created</th>
-                        <th>Updated</th>
+                        <th>Type</th>
                         <th>Info</th>
+                        <th>Updated</th>
                     </tr>
                     </thead>
                     <tbody>
                     {% for job in jobs_today_failed %}
                         <tr>
                             <td>{{ job.pk }}</td>
-                            <td>{{ job.status }}</td>
+                            <td>{{ job.get_status_code_name }}</td>
                             <td>{{ job.created }}</td>
-                            <td>{{ job.updated }}</td>
+                            <td>{{ job.task_type }}</td>
                             <td>{{ job.task_info_json }}</td>
+                            <td>{{ job.updated }}</td>
                         </tr>
                     {% endfor %}
                     </tbody>
@@ -109,18 +128,20 @@
                         <th>ID</th>
                         <th>Status</th>
                         <th>Created</th>
-                        <th>Updated</th>
+                        <th>Type</th>
                         <th>Info</th>
+                        <th>Updated</th>
                     </tr>
                     </thead>
                     <tbody>
                     {% for job in jobs_today_finished %}
                         <tr>
                             <td>{{ job.pk }}</td>
-                            <td>{{ job.status }}</td>
+                            <td>{{ job.get_status_code_name }}</td>
                             <td>{{ job.created }}</td>
-                            <td>{{ job.updated }}</td>
+                            <td>{{ job.task_type }}</td>
                             <td>{{ job.task_info_json }}</td>
+                            <td>{{ job.updated }}</td>
                         </tr>
                     {% endfor %}
                     </tbody>
@@ -133,32 +154,28 @@
                         <th>ID</th>
                         <th>Status</th>
                         <th>Created</th>
-                        <th>Updated</th>
+                        <th>Type</th>
                         <th>Info</th>
+                        <th>Updated</th>
                     </tr>
                     </thead>
                     <tbody>
                     {% for job in jobs_today_pending %}
                         <tr>
                             <td>{{ job.pk }}</td>
-                            <td>{{ job.status }}</td>
+                            <td>{{ job.get_status_code_name }}</td>
                             <td>{{ job.created }}</td>
-                            <td>{{ job.updated }}</td>
+                            <td>{{ job.task_type }}</td>
                             <td>{{ job.task_info_json }}</td>
+                            <td>{{ job.updated }}</td>
                         </tr>
                     {% endfor %}
                     </tbody>
                 </table>
             </div>
             <br>
-        </div>
 
-        <hr>
-
-        <div align="center">
-            <button class="btn btn-lg btn-primary" data-toggle="collapse" data-target="#jobs_last_fifty">
-                Last 50 Jobs
-            </button>
+            <!-- Last 50 jobs collapsable well-->
 
             <div id="jobs_last_fifty" class="collapse well">
                 <strong>Last 50 Jobs by creation date</strong>
@@ -168,18 +185,20 @@
                         <th>ID</th>
                         <th>Status</th>
                         <th>Created</th>
-                        <th>Updated</th>
+                        <th>Type</th>
                         <th>Info</th>
+                        <th>Updated</th>
                     </tr>
                     </thead>
                     <tbody>
                     {% for job in jobs_last_fifty %}
                         <tr>
                             <td>{{ job.pk }}</td>
-                            <td>{{ job.status }}</td>
+                            <td>{{ job.get_status_code_name }}</td>
                             <td>{{ job.created }}</td>
-                            <td>{{ job.updated }}</td>
+                            <td>{{ job.task_type }}</td>
                             <td>{{ job.task_info_json }}</td>
+                            <td>{{ job.updated }}</td>
                         </tr>
                     {% endfor %}
                     </tbody>
@@ -192,18 +211,20 @@
                         <th>ID</th>
                         <th>Status</th>
                         <th>Created</th>
-                        <th>Updated</th>
+                        <th>Type</th>
                         <th>Info</th>
+                        <th>Updated</th>
                     </tr>
                     </thead>
                     <tbody>
                     {% for job in jobs_last_fifty_updated %}
                         <tr>
                             <td>{{ job.pk }}</td>
-                            <td>{{ job.status }}</td>
+                            <td>{{ job.get_status_code_name }}</td>
                             <td>{{ job.created }}</td>
-                            <td>{{ job.updated }}</td>
+                            <td>{{ job.task_type }}</td>
                             <td>{{ job.task_info_json }}</td>
+                            <td>{{ job.updated }}</td>
                         </tr>
                     {% endfor %}
                     </tbody>
@@ -216,59 +237,90 @@
                         <th>ID</th>
                         <th>Status</th>
                         <th>Created</th>
-                        <th>Updated</th>
+                        <th>Type</th>
                         <th>Info</th>
+                        <th>Updated</th>
                     </tr>
                     </thead>
                     <tbody>
                     {% for job in jobs_last_fifty_failed %}
                         <tr class="bg-danger">
                             <td>{{ job.pk }}</td>
-                            <td>{{ job.status }}</td>
+                            <td>{{ job.get_status_code_name }}</td>
                             <td>{{ job.created }}</td>
-                            <td>{{ job.updated }}</td>
+                            <td>{{ job.task_type }}</td>
                             <td>{{ job.task_info_json }}</td>
+                            <td>{{ job.updated }}</td>
                         </tr>
                     {% endfor %}
                     </tbody>
                 </table>
             </div>
-        </div>
 
-        <hr>
-
-        <div align="center">
-            <button class="btn btn-lg btn-danger" data-toggle="collapse" data-target="#jobs_pending">
-                Stuck Pending Jobs
-            </button>
+            <!-- Stuck jobs hidden well -->
 
             <div id="jobs_pending" class="collapse well">
                 <strong>Pending jobs older than one day</strong>
-                <i>These jobs are older than one day, and are still on the pending status.</i>
+                <strong>Count: {{ jobs_pending_stuck_count }}</strong>
                 <table class="table table-striped table-bordered table-responsive">
                     <thead>
                     <tr>
                         <th>ID</th>
                         <th>Status</th>
                         <th>Created</th>
-                        <th>Updated</th>
+                        <th>Type</th>
                         <th>Info</th>
+                        <th>Updated</th>
                     </tr>
                     </thead>
                     <tbody class="bg-warning">
                     {% for job in jobs_pending_stuck %}
                         <tr>
                             <td>{{ job.pk }}</td>
-                            <td>{{ job.status }}</td>
+                            <td>{{ job.get_status_code_name }}</td>
                             <td>{{ job.created }}</td>
-                            <td>{{ job.updated }}</td>
+                            <td>{{ job.task_type }}</td>
                             <td>{{ job.task_info_json }}</td>
+                            <td>{{ job.updated }}</td>
+                        </tr>
+                    {% endfor %}
+                    </tbody>
+                </table>
+
+                <hr>
+
+                <strong>Running jobs older than one day</strong>
+                <strong>Count: {{ jobs_running_stuck_count }}</strong>
+                <table class="table table-striped table-bordered table-responsive">
+                    <thead>
+                    <tr>
+                        <th>ID</th>
+                        <th>Status</th>
+                        <th>Created</th>
+                        <th>Type</th>
+                        <th>Info</th>
+                        <th>Updated</th>
+                    </tr>
+                    </thead>
+                    <tbody class="bg-warning">
+                    {% for job in jobs_running_stuck %}
+                        <tr>
+                            <td>{{ job.pk }}</td>
+                            <td>{{ job.get_status_code_name }}</td>
+                            <td>{{ job.created }}</td>
+                            <td>{{ job.task_type }}</td>
+                            <td>{{ job.task_info_json }}</td>
+                            <td>{{ job.updated }}</td>
                         </tr>
                     {% endfor %}
                     </tbody>
                 </table>
             </div>
         </div>
+
+        <!-- End Job Tables -->
+
+        <hr>
 
         <p class="title" data-section-title width="100%" height="100%">
         <h1><a href="#settings">Settings</a></h1>

--- a/codalab/apps/health/templates/health/health.html
+++ b/codalab/apps/health/templates/health/health.html
@@ -52,269 +52,83 @@
 
             <div class="btn-group" role="group" aria-label="Button Group">
 
-                <button class="btn btn-lg btn-primary" data-toggle="collapse" data-target="#jobs_from_today">
-                    Jobs from today ({{ jobs_today_count }})
+                <button class="btn btn-sm btn-primary" data-toggle="collapse" data-target="#jobs_from_today">
+                    Today's Jobs ({{ jobs_today_count }})
                 </button>
 
-                <button class="btn btn-lg btn-primary" data-toggle="collapse" data-target="#jobs_last_fifty">
+                <button class="btn btn-sm btn-primary" data-toggle="collapse" data-target="#jobs_from_today_failed">
+                    Today's Failed Jobs ({{ jobs_today_failed_count }})
+                </button>
+
+                <button class="btn btn-sm btn-primary" data-toggle="collapse" data-target="#jobs_from_today_finished">
+                    Today's Finished Jobs ({{ jobs_today_finished_count }})
+                </button>
+
+                <button class="btn btn-sm btn-primary" data-toggle="collapse" data-target="#jobs_from_today_pending">
+                    Today's Pending Jobs ({{ jobs_today_pending_count }})
+                </button>
+
+                <button class="btn btn-sm btn-primary" data-toggle="collapse" data-target="#jobs_last_fifty">
                     Last 50 Jobs
                 </button>
 
-                <button class="btn btn-lg btn-danger" data-toggle="collapse" data-target="#jobs_pending">
-                    Stuck Jobs ({{ jobs_all_stuck_count }})
+                <button class="btn btn-sm btn-primary" data-toggle="collapse" data-target="#jobs_last_fifty_failed">
+                    Last 50 Jobs Failed
+                </button>
+
+                <button class="btn btn-sm btn-danger" data-toggle="collapse" data-target="#jobs_pending_stuck">
+                    Stuck Pending Jobs ({{ jobs_pending_stuck_count }})
+                </button>
+
+                <button class="btn btn-sm btn-danger" data-toggle="collapse" data-target="#jobs_running_stuck">
+                    Stuck Running Jobs ({{ jobs_running_stuck_count }})
                 </button>
 
             </div>
 
             <!-- Today's jobs collapsable well-->
-
             <div id="jobs_from_today" class="collapse well">
                 <strong>All jobs from today:</strong>
-                <table class="table table-bordered table-responsive">
-                    <thead>
-                    <tr>
-                        <th>ID</th>
-                        <th>Status</th>
-                        <th>Created</th>
-                        <th>Type</th>
-                        <th>Info</th>
-                        <th>Updated</th>
-                    </tr>
-                    </thead>
-                    <tbody>
-                    {% for job in jobs_today %}
-                        <tr>
-                            <td>{{ job.pk }}</td>
-                            <td>{{ job.get_status_code_name }}</td>
-                            <td>{{ job.created }}</td>
-                            <td>{{ job.task_type }}</td>
-                            <td>{{ job.task_info_json }}</td>
-                            <td>{{ job.updated }}</td>
-                        </tr>
-                    {% endfor %}
-                    </tbody>
-                </table>
 
-                <strong>Failed jobs from today:</strong>
-                <table class="table table-bordered table-responsive bg-danger">
-                    <thead>
-                    <tr>
-                        <th>ID</th>
-                        <th>Status</th>
-                        <th>Created</th>
-                        <th>Type</th>
-                        <th>Info</th>
-                        <th>Updated</th>
-                    </tr>
-                    </thead>
-                    <tbody>
-                    {% for job in jobs_today_failed %}
-                        <tr>
-                            <td>{{ job.pk }}</td>
-                            <td>{{ job.get_status_code_name }}</td>
-                            <td>{{ job.created }}</td>
-                            <td>{{ job.task_type }}</td>
-                            <td>{{ job.task_info_json }}</td>
-                            <td>{{ job.updated }}</td>
-                        </tr>
-                    {% endfor %}
-                    </tbody>
-                </table>
-
-                <strong>Finished jobs from today:</strong>
-                <table class="table table-bordered table-responsive bg-success">
-                    <thead>
-                    <tr>
-                        <th>ID</th>
-                        <th>Status</th>
-                        <th>Created</th>
-                        <th>Type</th>
-                        <th>Info</th>
-                        <th>Updated</th>
-                    </tr>
-                    </thead>
-                    <tbody>
-                    {% for job in jobs_today_finished %}
-                        <tr>
-                            <td>{{ job.pk }}</td>
-                            <td>{{ job.get_status_code_name }}</td>
-                            <td>{{ job.created }}</td>
-                            <td>{{ job.task_type }}</td>
-                            <td>{{ job.task_info_json }}</td>
-                            <td>{{ job.updated }}</td>
-                        </tr>
-                    {% endfor %}
-                    </tbody>
-                </table>
-
-                <strong>Pending jobs from today:</strong>
-                <table class="table table-bordered table-responsive bg-warning">
-                    <thead>
-                    <tr>
-                        <th>ID</th>
-                        <th>Status</th>
-                        <th>Created</th>
-                        <th>Type</th>
-                        <th>Info</th>
-                        <th>Updated</th>
-                    </tr>
-                    </thead>
-                    <tbody>
-                    {% for job in jobs_today_pending %}
-                        <tr>
-                            <td>{{ job.pk }}</td>
-                            <td>{{ job.get_status_code_name }}</td>
-                            <td>{{ job.created }}</td>
-                            <td>{{ job.task_type }}</td>
-                            <td>{{ job.task_info_json }}</td>
-                            <td>{{ job.updated }}</td>
-                        </tr>
-                    {% endfor %}
-                    </tbody>
-                </table>
+                {% include "health/_job_table.html" with jobs_list=jobs_today %}
             </div>
-            <br>
+            <div id="jobs_from_today_failed" class="collapse well">
+                <strong>All jobs from today failed:</strong>
+                {% include "health/_job_table.html" with jobs_list=jobs_today_failed %}
+            </div>
+            <div id="jobs_from_today_finished" class="collapse well">
+                <strong>All jobs from today finished:</strong>
+                {% include "health/_job_table.html" with jobs_list=jobs_today_finished %}
+            </div>
+            <div id="jobs_from_today_pending" class="collapse well">
+                <strong>All jobs from today pending:</strong>
+                {% include "health/_job_table.html" with jobs_list=jobs_today_pending%}
+            </div>
 
             <!-- Last 50 jobs collapsable well-->
 
             <div id="jobs_last_fifty" class="collapse well">
-                <strong>Last 50 Jobs by creation date</strong>
-                <table class="table table-striped table-bordered table-responsive">
-                    <thead>
-                    <tr>
-                        <th>ID</th>
-                        <th>Status</th>
-                        <th>Created</th>
-                        <th>Type</th>
-                        <th>Info</th>
-                        <th>Updated</th>
-                    </tr>
-                    </thead>
-                    <tbody>
-                    {% for job in jobs_last_fifty %}
-                        <tr>
-                            <td>{{ job.pk }}</td>
-                            <td>{{ job.get_status_code_name }}</td>
-                            <td>{{ job.created }}</td>
-                            <td>{{ job.task_type }}</td>
-                            <td>{{ job.task_info_json }}</td>
-                            <td>{{ job.updated }}</td>
-                        </tr>
-                    {% endfor %}
-                    </tbody>
-                </table>
-
                 <strong>Last 50 Jobs by update date</strong>
-                <table class="table table-striped table-bordered table-responsive">
-                    <thead>
-                    <tr>
-                        <th>ID</th>
-                        <th>Status</th>
-                        <th>Created</th>
-                        <th>Type</th>
-                        <th>Info</th>
-                        <th>Updated</th>
-                    </tr>
-                    </thead>
-                    <tbody>
-                    {% for job in jobs_last_fifty_updated %}
-                        <tr>
-                            <td>{{ job.pk }}</td>
-                            <td>{{ job.get_status_code_name }}</td>
-                            <td>{{ job.created }}</td>
-                            <td>{{ job.task_type }}</td>
-                            <td>{{ job.task_info_json }}</td>
-                            <td>{{ job.updated }}</td>
-                        </tr>
-                    {% endfor %}
-                    </tbody>
-                </table>
 
+                {% include "health/_job_table.html" with jobs_list=jobs_last_fifty_updated %}
+            </div>
+            <div id="jobs_last_fifty_failed" class="collapse well">
                 <strong>Last 50 failed jobs by update date</strong>
-                <table class="table table-bordered table-striped table-responsive">
-                    <thead>
-                    <tr>
-                        <th>ID</th>
-                        <th>Status</th>
-                        <th>Created</th>
-                        <th>Type</th>
-                        <th>Info</th>
-                        <th>Updated</th>
-                    </tr>
-                    </thead>
-                    <tbody>
-                    {% for job in jobs_last_fifty_failed %}
-                        <tr class="bg-danger">
-                            <td>{{ job.pk }}</td>
-                            <td>{{ job.get_status_code_name }}</td>
-                            <td>{{ job.created }}</td>
-                            <td>{{ job.task_type }}</td>
-                            <td>{{ job.task_info_json }}</td>
-                            <td>{{ job.updated }}</td>
-                        </tr>
-                    {% endfor %}
-                    </tbody>
-                </table>
+
+                {% include "health/_job_table.html" with jobs_list=last_fifty_failed %}
             </div>
 
             <!-- Stuck jobs hidden well -->
 
-            <div id="jobs_pending" class="collapse well">
+            <div id="jobs_pending_stuck" class="collapse well">
                 <strong>Pending jobs older than one day</strong>
                 <strong>Count: {{ jobs_pending_stuck_count }}</strong>
-                <table class="table table-striped table-bordered table-responsive">
-                    <thead>
-                    <tr>
-                        <th>ID</th>
-                        <th>Status</th>
-                        <th>Created</th>
-                        <th>Type</th>
-                        <th>Info</th>
-                        <th>Updated</th>
-                    </tr>
-                    </thead>
-                    <tbody class="bg-warning">
-                    {% for job in jobs_pending_stuck %}
-                        <tr>
-                            <td>{{ job.pk }}</td>
-                            <td>{{ job.get_status_code_name }}</td>
-                            <td>{{ job.created }}</td>
-                            <td>{{ job.task_type }}</td>
-                            <td>{{ job.task_info_json }}</td>
-                            <td>{{ job.updated }}</td>
-                        </tr>
-                    {% endfor %}
-                    </tbody>
-                </table>
-
-                <hr>
-
+                {% include "health/_job_table.html" with jobs_list=jobs_pending_stuck %}
+            </div>
+            <div id="jobs_running_stuck" class="collapse well">
                 <strong>Running jobs older than one day</strong>
                 <strong>Count: {{ jobs_running_stuck_count }}</strong>
-                <table class="table table-striped table-bordered table-responsive">
-                    <thead>
-                    <tr>
-                        <th>ID</th>
-                        <th>Status</th>
-                        <th>Created</th>
-                        <th>Type</th>
-                        <th>Info</th>
-                        <th>Updated</th>
-                    </tr>
-                    </thead>
-                    <tbody class="bg-warning">
-                    {% for job in jobs_running_stuck %}
-                        <tr>
-                            <td>{{ job.pk }}</td>
-                            <td>{{ job.get_status_code_name }}</td>
-                            <td>{{ job.created }}</td>
-                            <td>{{ job.task_type }}</td>
-                            <td>{{ job.task_info_json }}</td>
-                            <td>{{ job.updated }}</td>
-                        </tr>
-                    {% endfor %}
-                    </tbody>
-                </table>
+                {% include "health/_job_table.html" with jobs_list=jobs_running_stuck %}
             </div>
         </div>
 

--- a/codalab/apps/health/views.py
+++ b/codalab/apps/health/views.py
@@ -77,6 +77,7 @@ def get_health_metrics():
     jobs_last_fifty_failed = Job.objects.filter(status=Job.FAILED).order_by('-updated')[0:50]
 
     jobs_pending_stuck = Job.objects.filter(status=Job.PENDING, created__lt=datetime.now() + timedelta(days=1))
+    jobs_running_stuck = Job.objects.filter(status=Job.RUNNING, created__lt=datetime.now() + timedelta(days=1))
 
     context['jobs_today'] = jobs_today
     context['jobs_today_count'] = len(jobs_today)
@@ -91,6 +92,10 @@ def get_health_metrics():
     context['jobs_last_fifty_updated'] = jobs_last_fifty_updated
     context['jobs_last_fifty_failed'] = jobs_last_fifty_failed
     context['jobs_pending_stuck'] = jobs_pending_stuck
+    context['jobs_pending_stuck_count'] = len(jobs_pending_stuck)
+    context['jobs_running_stuck'] = jobs_running_stuck
+    context['jobs_running_stuck_count'] = len(jobs_running_stuck)
+    context['jobs_all_stuck_count'] = len(jobs_running_stuck) + len(jobs_pending_stuck)
 
     return context
 

--- a/codalab/apps/health/views.py
+++ b/codalab/apps/health/views.py
@@ -26,7 +26,6 @@ def get_health_metrics():
     - **alert_threshold** Threshold number.
     """
     jobs_pending = Job.objects.filter(status=Job.PENDING)
-    # jobs_pending_count = len(jobs_pending)
 
     jobs_finished_in_last_2_days = Job.objects.filter(status=Job.FINISHED, created__gt=datetime.now() - timedelta(days=2))
     jobs_finished_in_last_2_days_count = len(jobs_finished_in_last_2_days)

--- a/codalab/apps/health/views.py
+++ b/codalab/apps/health/views.py
@@ -26,7 +26,7 @@ def get_health_metrics():
     - **alert_threshold** Threshold number.
     """
     jobs_pending = Job.objects.filter(status=Job.PENDING)
-    jobs_pending_count = len(jobs_pending)
+    # jobs_pending_count = len(jobs_pending)
 
     jobs_finished_in_last_2_days = Job.objects.filter(status=Job.FINISHED, created__gt=datetime.now() - timedelta(days=2))
     jobs_finished_in_last_2_days_count = len(jobs_finished_in_last_2_days)
@@ -51,9 +51,9 @@ def get_health_metrics():
 
     alert_emails = health_settings.emails if health_settings.emails else ""
 
-    return {
+    context = {
         "jobs_pending": jobs_pending,
-        "jobs_pending_count": jobs_pending_count,
+        "jobs_pending_count": len(jobs_pending),
         "jobs_finished_in_last_2_days_avg": jobs_finished_in_last_2_days_avg,
         "jobs_lasting_longer_than_10_minutes": jobs_lasting_longer_than_10_minutes,
         "jobs_failed": jobs_failed,
@@ -61,6 +61,38 @@ def get_health_metrics():
         "alert_emails": alert_emails,
         "alert_threshold": health_settings.threshold
     }
+
+    # Health page update Dec 22, 2017
+
+    # Today's jobs
+    jobs_today = Job.objects.filter(created__year=datetime.today().year,
+                                    created__day=datetime.today().day,
+                                    created__month=datetime.today().month)
+    jobs_today_failed = jobs_today.filter(status=Job.FAILED)
+    jobs_today_finished = jobs_today.filter(status=Job.FINISHED)
+    jobs_today_pending = jobs_today.filter(status=Job.PENDING)
+
+    jobs_last_fifty = Job.objects.all().order_by('-created')[0:50]
+    jobs_last_fifty_updated = Job.objects.all().order_by('-updated')[0:50]
+    jobs_last_fifty_failed = Job.objects.filter(status=Job.FAILED).order_by('-updated')[0:50]
+
+    jobs_pending_stuck = Job.objects.filter(status=Job.PENDING, created__lt=datetime.now() + timedelta(days=1))
+
+    context['jobs_today'] = jobs_today
+    context['jobs_today_count'] = len(jobs_today)
+    context['jobs_today_failed'] = jobs_today_failed
+    context['jobs_today_failed_count'] = len(jobs_today_failed)
+    context['jobs_today_finished'] = jobs_today_finished
+    context['jobs_today_finished_count'] = len(jobs_today_finished)
+    context['jobs_today_pending'] = jobs_today_pending
+    context['jobs_today_pending_count'] = len(jobs_today_pending)
+
+    context['jobs_last_fifty'] = jobs_last_fifty
+    context['jobs_last_fifty_updated'] = jobs_last_fifty_updated
+    context['jobs_last_fifty_failed'] = jobs_last_fifty_failed
+    context['jobs_pending_stuck'] = jobs_pending_stuck
+
+    return context
 
 
 @login_required

--- a/codalab/apps/jobs/models.py
+++ b/codalab/apps/jobs/models.py
@@ -77,6 +77,7 @@ class JobManager(models.Manager):
         getQueue(queue_name).send_message(job.create_json_message())
         return job
 
+
 class Job(models.Model):
     """
     Defines a job which will carry out a long running task.


### PR DESCRIPTION
Adds a lot more information to the health page.

Tables added:
- Submissions from the current day
  * All, failed, pending, finished
- Submissions that are `stuck`
  * Have been on status of pending/running while having been created over a day ago.
- Last 50 jobs
  * By Creation Date
  * By Updated Date
  * By last 50 failed.

<img width="1270" alt="screen shot 2017-12-22 at 1 15 37 pm" src="https://user-images.githubusercontent.com/28552312/34312606-3c735a6a-e71a-11e7-9d2e-6a20c00ce5bb.png">
