### PR TITLE
Clean HTML cast to unicode instead of string

### DIFF
--- a/codalab/apps/web/tests/test_html_clean.py
+++ b/codalab/apps/web/tests/test_html_clean.py
@@ -1,3 +1,4 @@
+# -*- encoding: utf-8 -*-
 from django.test import TestCase
 
 from apps.authenz.models import ClUser
@@ -8,9 +9,14 @@ class HTMLCleanTestCase(TestCase):
     def test_script_tags_get_removed_from_html_content(self):
         self.assertEquals(clean_html_script("<script></script>"), "")
         self.assertEquals(clean_html_script("<script src=\"https://www.googleorsomething\"></script>"), "")
-        self.assertEquals(clean_html_script("<script src=\"https://www.googleorsomething\">There's some stuff in between here too </script>"), "")
-        self.assertEquals(clean_html_script("<script src=\"https://www.googleorsomething\">There's some stuff in between here too </script>There should be some stuff here."), "There should be some stuff here.")
+        self.assertEquals(clean_html_script(
+            "<script src=\"https://www.googleorsomething\">There's some stuff in between here too </script>"), "")
+        self.assertEquals(clean_html_script(
+            "<script src=\"https://www.googleorsomething\">There's some stuff in between here too </script>There should be some stuff here."),
+                          "There should be some stuff here.")
         self.assertEquals(clean_html_script("<b>A strong word</b>"), "<b>A strong word</b>")
+        self.assertEquals(clean_html_script(u'<h1 class="char Zinh U030C" data-text="̌">̌</h1>'),
+                          u'<h1 class="char Zinh U030C" data-text="̌">̌</h1>')
         self.assertEquals(clean_html_script({
             'my_key': 1,
             'my_value': "twenty_seven",

--- a/codalab/apps/web/utils.py
+++ b/codalab/apps/web/utils.py
@@ -27,7 +27,7 @@ else:
 
 def clean_html_script(html_content):
     # Finds <script and everything between /script>. No scripts for you.
-    return re.sub('(<script)(\s*?\S*?)*?(/script>)', "", str(html_content))
+    return re.sub('(<script)(\s*?\S*?)*?(/script>)', "", unicode(html_content))
 
 
 def docker_image_clean(image_name):


### PR DESCRIPTION
Fixes: ```UnicodeEncodeError: 'ascii' codec can't encode character u'\u030c' in position 8230: ordinal not in range(128)``` when cleaning HTML pages.