### PR TITLE
Fix Docker Image Clean Stripping Hyphens

### DIFF
--- a/codalab/apps/web/tests/test_docker_image_sanitation.py
+++ b/codalab/apps/web/tests/test_docker_image_sanitation.py
@@ -18,6 +18,7 @@ class DockerImageSanitationTests(TestCase):
         self._sanitize("continuumio/anaconda:4.3.0 && ls -all || ls.txt", "continuumio/anaconda:4.3.0")
         self._sanitize("continuumio/ anaconda:4.3.0", "continuumio/")
         self._sanitize("continuumio/anaconda:4.3.0", "continuumio/anaconda:4.3.0")
+        self._sanitize("continuumio/anaconda-test:4.3.0", "continuumio/anaconda-test:4.3.0")
         self._sanitize("'sudo bash'", "sudo")
 
         # Handles empties

--- a/codalab/apps/web/utils.py
+++ b/codalab/apps/web/utils.py
@@ -38,7 +38,7 @@ def docker_image_clean(image_name):
     image_name = '"{}"'.format(image_name.strip().split(' ')[0])
     # Regex acts as a whitelist here. Only alphanumerics and the following symbols are allowed: / . : -.
     # If any not allowed are found, replaced with second argument to sub.
-    image_name = re.sub('[^0-9a-zA-Z/.:-_]+', '', image_name)
+    image_name = re.sub('[^0-9a-zA-Z/.:\-_]+', '', image_name)
     return image_name
 
 


### PR DESCRIPTION
Fixes the exclusion rule for hyphens in docker image names.(#2147)