### PR TITLE
Fix team count to include owner

### DIFF
--- a/codalab/apps/teams/models.py
+++ b/codalab/apps/teams/models.py
@@ -230,6 +230,10 @@ class Team(models.Model):
         return self.get_members("approved")
 
     @cached_property
+    def active_members_count(self):
+        return len(self.get_members("approved")) + 1
+
+    @cached_property
     def active_requests(self):
         return self.get_members("pending")
 

--- a/codalab/apps/teams/templates/teams/tiles/team_details.html
+++ b/codalab/apps/teams/templates/teams/tiles/team_details.html
@@ -27,7 +27,7 @@
 		</div>
     	<div class="col-sm-4 col-md-4 right-panel">
 			{{ team.created_at|date:"M d, Y" }}<br>
-            <b>{{ team.active_members|length}}</b> member{% if team.active_members|length > 1 %}s{% endif %}<br>
+            <b>{{ team.active_members_count}}</b> member{% if team.active_members_count > 1 %}s{% endif %}<br>
         </div>
 
         <br><br>


### PR DESCRIPTION
Addresses Issue: #2180 

Team member count should now include the owner by default. Adds a cached helper method to return the number of team members.