### PR TITLE
Admin Feature: Impersonate Users

### DIFF
--- a/codalab/apps/web/middleware.py
+++ b/codalab/apps/web/middleware.py
@@ -6,7 +6,7 @@ import tempfile
 import StringIO
 
 from django.conf import settings
-from userswitch.middleware import UserSwitchMiddleware
+# from userswitch.middleware import UserSwitchMiddleware
 
 from apps.customizer.models import Configuration
 
@@ -126,17 +126,17 @@ class SingleCompetitionMiddleware(object):
                 settings.CUSTOM_HEADER_LOGO = config.header_logo.url
 
 
-class CodalabUserSwitchMiddleware(UserSwitchMiddleware):
-    """Augments the UserSwitchMiddleware helper from django-debug-toolbar to only allow superusers to
-    use this feature."""
-
-    def process_request(self, request):
-        if hasattr(request, 'user'):
-            if request.user.is_authenticated() and request.user.is_superuser:
-                return super(CodalabUserSwitchMiddleware, self).process_request(request)
-
-    def process_response(self, request, response):
-        if hasattr(request, 'user'):
-            if request.user.is_authenticated() and request.user.is_superuser:
-                return super(CodalabUserSwitchMiddleware, self).process_response(request, response)
-        return response
+# class CodalabUserSwitchMiddleware(UserSwitchMiddleware):
+#     """Augments the UserSwitchMiddleware helper from django-debug-toolbar to only allow superusers to
+#     use this feature."""
+#
+#     def process_request(self, request):
+#         if hasattr(request, 'user'):
+#             if request.user.is_authenticated() and request.user.is_superuser:
+#                 return super(CodalabUserSwitchMiddleware, self).process_request(request)
+#
+#     def process_response(self, request, response):
+#         if hasattr(request, 'user'):
+#             if request.user.is_authenticated() and request.user.is_superuser:
+#                 return super(CodalabUserSwitchMiddleware, self).process_response(request, response)
+#         return response

--- a/codalab/apps/web/templates/base.html
+++ b/codalab/apps/web/templates/base.html
@@ -118,6 +118,8 @@
                                         <li class="divider"></li>
                                         <li><a href="{% url 'customize_codalab' %}">Customize Codalab</a></li>
                                         <li class="divider"></li>
+                                        <li><a href="{% url 'su-login' %}">Switch User</a></li>
+                                        <li class="divider"></li>
                                     {% endif %}
                                     <li><a href="{% url 'user_settings' %}">Settings</a></li>
                                     <li class="divider"></li>

--- a/codalab/codalab/settings/base.py
+++ b/codalab/codalab/settings/base.py
@@ -151,6 +151,7 @@ class Base(Settings):
     )
 
     MIDDLEWARE_CLASSES = (
+        "django_switchuser.middleware.SuStateMiddleware",
         'apps.web.middleware.SingleCompetitionMiddleware',
         'django.middleware.common.CommonMiddleware',
         'django.contrib.sessions.middleware.SessionMiddleware',
@@ -168,10 +169,11 @@ class Base(Settings):
         # Put strings here, like "/home/html/django_templates" or "C:/www/django/templates".
         # Always use forward slashes, even on Windows.
         # Don't forget to use absolute paths, not relative paths.
-        os.path.join(PROJECT_DIR,'templates'),
+        os.path.join(PROJECT_DIR, 'templates'),
     )
 
     TEMPLATE_CONTEXT_PROCESSORS = Settings.TEMPLATE_CONTEXT_PROCESSORS + (
+        "django_switchuser.context_processors.su_state",
         "allauth.account.context_processors.account",
         "allauth.socialaccount.context_processors.socialaccount",
         "codalab.context_processors.app_version_proc",
@@ -245,6 +247,9 @@ class Base(Settings):
         # Search
         'haystack',
         'django_extensions',
+
+        # Switch User
+        "django_switchuser",
 
         # Lockout
         'pin_passcode',
@@ -602,10 +607,10 @@ class Base(Settings):
         'group_models': True,
     }
 
-    USERSWITCH_OPTIONS = {
-        'auth_backend': 'django.contrib.auth.backends.ModelBackend',
-        'css_inline': 'position:fixed !important; bottom: 10px !important; left: 10px !important; opacity:0.50; z-index: 9999;',
-    }
+    # USERSWITCH_OPTIONS = {
+    #     'auth_backend': 'django.contrib.auth.backends.ModelBackend',
+    #     'css_inline': 'position:fixed !important; bottom: 10px !important; left: 10px !important; opacity:0.50; z-index: 9999;',
+    # }
 
     @classmethod
     def pre_setup(cls):
@@ -643,10 +648,10 @@ class DevBase(Base):
             'debug_toolbar.middleware.DebugToolbarMiddleware',
         )
 
-        if os.environ.get('USER_SWITCH_MIDDLEWARE', False):
-            EXTRA_MIDDLEWARE_CLASSES += (
-                'userswitch.middleware.UserSwitchMiddleware',
-            )
+        # if os.environ.get('USER_SWITCH_MIDDLEWARE', False):
+        #     EXTRA_MIDDLEWARE_CLASSES += (
+        #         'userswitch.middleware.UserSwitchMiddleware',
+        #     )
 
         DEBUG_TOOLBAR_CONFIG = {
             'SHOW_TEMPLATE_CONTEXT': True,

--- a/codalab/codalab/urls.py
+++ b/codalab/codalab/urls.py
@@ -25,6 +25,9 @@ urlpatterns = patterns('',
 
     url(r'^', include('pin_passcode.urls')),
 
+    # Switch User
+    url(r"^su/", include("django_switchuser.urls")),
+
     # Static files
     url(r'^static/(?P<path>.*)$', 'django.views.static.serve',
         {'document_root': settings.STATIC_ROOT}),

--- a/codalab/requirements/common.txt
+++ b/codalab/requirements/common.txt
@@ -57,7 +57,8 @@ gunicorn==19.7.0
 #gevent==1.2.2
 
 #Extras added
-git+https://github.com/ikraft/django-userswitch.git
+#git+https://github.com/ikraft/django-userswitch.git
+git+https://github.com/Tthomas63/django-switchuser.git
 Sphinx==1.4.1
 
 

--- a/codalab/templates/su/login_form.html
+++ b/codalab/templates/su/login_form.html
@@ -1,0 +1,39 @@
+{% extends 'base.html' %}
+
+{% load switchuser %}
+{% load url from future %}
+
+{% block head_title %}Switch-User{% endblock %}
+
+{% block content %}
+    {% if not su_state %}
+        <div class="alert alert-danger">
+            Error: the <tt>su_state</tt> context processor was not found. Is
+            <tt>"django_switchuser.context_processors.su_state"</tt> in your list
+            of <tt>TEMPLATE_CONTEXT_PROCESSORS</tt>?
+        </div>
+    {% else %}
+        {% if su_state.is_active %}
+            <div class="alert alert-success">
+                Currently logged in as: <em>{% su_user_short_label su_state.active_user %}</em>
+            </div>
+        {% endif %}
+        <div align="center" class="well">
+            <form method="POST" action="{% url "su-login" %}?next={{ next }}">
+                {% csrf_token %}
+                <label for="user_id">Login as:</label>
+                <br>
+                <select name="user_id">
+                    {% for user in su_state.available_users %}
+                        <option value="{{ user.id }}">{% su_user_long_label user %}</option>
+                    {% endfor %}
+                </select>
+                <br>
+                <br>
+                <input class="btn btn-success btn-large" type="submit" value="Switch-User"/>
+            </form>
+        <hr>
+            {% include "su/logout_form.html" %}
+        </div>
+    {% endif %}
+{% endblock %}

--- a/codalab/templates/su/logout_form.html
+++ b/codalab/templates/su/logout_form.html
@@ -1,0 +1,11 @@
+{% load switchuser %}
+{% load url from future %}
+
+<form method="POST" action="{% url "su-logout" %}?next={{ next }}">
+  {% csrf_token %}
+  {% if su_state.is_active %}
+    <input class="btn btn-danger" type="submit" value="Revert-User (back to {% su_user_short_label su_state.auth_user %})" />
+  {% else %}
+    <input class="btn btn-danger" type="submit" value="Revert-User (not active)" disabled="disabled" />
+  {% endif %}
+</form>


### PR DESCRIPTION
Adds a feature for super-admins to impersonate other users through `/su/`

 - Currently overwrites templates used with custom ones
 - Cruft from old Debug switch user middleware still present