### PR TITLE
Add check to submissions if they're past competition end

### DIFF
--- a/codalab/apps/web/models.py
+++ b/codalab/apps/web/models.py
@@ -1422,6 +1422,10 @@ class CompetitionSubmission(ChaHubSaveMixin, models.Model):
                 else:
                     print "Submission number below maximum."
 
+                if self.phase.competition.end_date and datetime.date.today() > self.phase.competition.end_date.date():
+                    print "Submission is past competition end."
+                    raise PermissionDenied("The competition has ended. No more submissions are allowed.")
+
                 if hasattr(self.phase, 'max_submissions_per_day'):
                     print 'Checking submissions per day count'
 


### PR DESCRIPTION
Addresses issue #2233 

Checks if the submission is past the competition deadline (If it exists). If so throw an error.