### PR TITLE
A-Teams

### DIFF
--- a/codalab/apps/teams/forms.py
+++ b/codalab/apps/teams/forms.py
@@ -1,13 +1,18 @@
 from django import forms
+from django.core.exceptions import ValidationError
+from django.db.models import Q
 from django.forms.widgets import ClearableFileInput, Input, CheckboxInput
 from django.utils.html import escape, conditional_escape
 from django.utils.encoding import force_unicode
-from .models import Team, TeamMembership
 from tinymce.widgets import TinyMCE
-from django.utils.html import format_html
-from django.utils.encoding import force_text
+from django.utils import timezone
+from apps.web.models import Competition
+from apps.authenz.models import ClUser
+from apps.teams.models import TeamMembership, Team, TeamStatus, TeamMembershipStatus
 from django.utils.safestring import mark_safe
 import os
+import datetime
+
 
 class CustomImageField(ClearableFileInput):
 
@@ -36,6 +41,7 @@ class CustomImageField(ClearableFileInput):
                 substitutions['clear_template'] = clear_template % substitutions
 
         return mark_safe(template % substitutions)
+
 
 class TeamEditForm(forms.ModelForm):
     name = forms.CharField(max_length=64, required=False)
@@ -89,3 +95,137 @@ class TeamMembershipForm(forms.ModelForm):
         cleaned_data = super(TeamMembershipForm, self).clean()
 
         return cleaned_data
+
+
+class OrganizerTeamForm(forms.ModelForm):
+
+    text_members = forms.CharField(required=False, widget=forms.Textarea)
+
+    class Meta:
+        model = Team
+        fields = ('description', 'name')
+
+    def __init__(self, *args, **kwargs):
+        self.user_list = []
+        self.competition = Competition.objects.get(pk=kwargs.pop('competition_pk'))
+        self.creator = ClUser.objects.get(pk=kwargs.pop('creator_pk'))
+        super(OrganizerTeamForm, self).__init__(*args, **kwargs)
+        # This check is to see if we have an existing object with a PK, or if we're making a new one
+        # If we have an existing we grab existing members for the form.
+        if hasattr(self, 'instance'):
+            if hasattr(self.instance, 'pk'):
+                if self.instance and self.instance.pk:
+                    team = Team.objects.get(pk=self.instance.pk)
+                    current_members = team.members.all()
+                    name_text_list = ""
+                    name_list = []
+                    for member in current_members:
+                        name_list.append(member.username)
+                        name_text_list = ",".join(name_list)
+                    self.initial['text_members'] = name_text_list
+
+    def clean_text_members(self):
+        if self.cleaned_data.get('text_members'):
+            team_members_text = self.cleaned_data.get('text_members')
+            team_members_list = team_members_text.replace(' ','').split(',')
+            # team_members_list = team_members_text.replace(' ','').split('\n')
+            self.user_list = ClUser.objects.filter(Q(username__in=team_members_list) | Q(email__in=team_members_list))
+
+    def clean_name(self):
+        if self.cleaned_data.get('name'):
+            existing_team_with_name = Team.objects.filter(name=self.cleaned_data.get('name'))
+            if existing_team_with_name:
+                raise ValidationError(('Invalid value for name. A team already exists with that name.'), code='invalid')
+        return self.cleaned_data.get('name')
+
+    def save(self, commit=True):
+        self.instance.creator = self.creator
+        self.instance.competition = self.competition
+        self.instance.status = TeamStatus.objects.get(codename=TeamStatus.APPROVED)
+
+        # We need to call save before adding members
+        self.instance.save()
+
+        if hasattr(self, 'user_list'):
+            # On save, if we have existing objects, clear it. We only add names in the form.
+            if len(self.instance.members.all()) > 0:
+                # Remove users no longer in the list
+                for user in self.instance.members.all():
+                    if user not in self.user_list:
+                        # Delete members not on the new list
+                        print("Deleting membership for user: {}".format(user))
+                        TeamMembership.objects.get(user=user, team=self.instance).delete()
+            # Then we loop through the names/emails they gave us.
+            for user in self.user_list:
+                if user not in self.instance.members.all():
+                    # There is not already an existing membership for this user.
+                    new_team_membership = TeamMembership.objects.create(
+                        user=user,
+                        team=self.instance,
+                        is_invitation=False,
+                        is_request=False,
+                        start_date=timezone.now(),
+                        end_date=timezone.now() + datetime.timedelta(days=9000),
+                        message="Organizer Created",
+                        status=TeamMembershipStatus.objects.get(codename=TeamMembershipStatus.APPROVED),
+                        reason="Organizer Created Team"
+                    )
+                    print("Created new membership: {0} for user: {1} on team: {2}".format(new_team_membership, user, self.instance))
+                else:
+                    print("Existing membership found for user on team.")
+        return super(OrganizerTeamForm, self).save(commit=commit)
+
+
+class OrganizerTeamsCSVForm(forms.Form):
+
+    csv_file = forms.FileField(required=False)
+
+    def __init__(self, *args, **kwargs):
+        self.competition = Competition.objects.get(pk=kwargs.pop('competition_pk'))
+        self.creator = ClUser.objects.get(pk=kwargs.pop('creator_pk'))
+        self.teams_dict = {}
+        super(OrganizerTeamsCSVForm, self).__init__(*args, **kwargs)
+
+    def clean_csv_file(self):
+        teams_dict = {}
+        if self.cleaned_data.get('csv_file'):
+            temp_csv = self.cleaned_data.get('csv_file')
+            csv_team_list = [line.rstrip() for line in temp_csv]
+            for index, value in enumerate(csv_team_list):
+                temp_line = value.replace(' ', '').split(',')
+                # Pop the team name (First value), into the dict key, then the rest of the list is users.
+                teams_dict[temp_line.pop(0)] = temp_line
+        self.teams_dict = teams_dict
+
+        for team_name in self.teams_dict:
+            if Team.objects.get(name=team_name):
+                raise ValidationError("A team with that name already exists!")
+
+    def save(self):
+        if hasattr(self, 'teams_dict'):
+            for team_name, team_member_list in self.teams_dict.iteritems():
+                new_team = Team.objects.create(
+                    name=team_name,
+                    competition=self.competition,
+                    description=team_name,
+                    allow_requests=False,
+                    creator=self.creator,
+                    created_at=timezone.now(),
+                    status=TeamStatus.objects.get(codename=TeamStatus.APPROVED),
+                    reason="Organizer Created Team"
+                )
+                print("Created new team: {}".format(new_team))
+                user_list = ClUser.objects.filter(Q(username__in=team_member_list) | Q(email__in=team_member_list))
+                for user in user_list:
+                    new_team_membership = TeamMembership.objects.create(
+                        user=user,
+                        team=new_team,
+                        is_invitation=False,
+                        is_request=False,
+                        start_date=timezone.now(),
+                        end_date=timezone.now() + datetime.timedelta(days=9000),
+                        message="Organizer Created",
+                        status=TeamMembershipStatus.objects.get(codename=TeamMembershipStatus.APPROVED),
+                        reason="Organizer Created Team"
+                    )
+                    print("Created new membership for user: {0} on team: {1}".format(user, new_team))

--- a/codalab/apps/teams/forms.py
+++ b/codalab/apps/teams/forms.py
@@ -133,9 +133,17 @@ class OrganizerTeamForm(forms.ModelForm):
 
     def clean_name(self):
         if self.cleaned_data.get('name'):
-            existing_team_with_name = Team.objects.filter(name=self.cleaned_data.get('name'))
-            if existing_team_with_name:
-                raise ValidationError(('Invalid value for name. A team already exists with that name.'), code='invalid')
+            if hasattr(self, 'instance'):
+                if self.instance.pk:
+                    print("WE HAVE A PK AS WELL IN FORM")
+                    existing_team_with_name = Team.objects.filter(name=self.cleaned_data.get('name')).exclude(pk=self.instance.pk)
+                    if existing_team_with_name:
+                        raise ValidationError(('Invalid value for name. A team already exists with that name.'),
+                                              code='invalid')
+            else:
+                existing_team_with_name = Team.objects.filter(name=self.cleaned_data.get('name'))
+                if existing_team_with_name:
+                    raise ValidationError(('Invalid value for name. A team already exists with that name.'), code='invalid')
         return self.cleaned_data.get('name')
 
     def save(self, commit=True):
@@ -198,7 +206,7 @@ class OrganizerTeamsCSVForm(forms.Form):
         self.teams_dict = teams_dict
 
         for team_name in self.teams_dict:
-            if Team.objects.get(name=team_name):
+            if Team.objects.filter(name=team_name):
                 raise ValidationError("A team with that name already exists!")
 
     def save(self):

--- a/codalab/apps/teams/forms.py
+++ b/codalab/apps/teams/forms.py
@@ -135,7 +135,6 @@ class OrganizerTeamForm(forms.ModelForm):
         if self.cleaned_data.get('name'):
             if hasattr(self, 'instance'):
                 if self.instance.pk:
-                    print("WE HAVE A PK AS WELL IN FORM")
                     existing_team_with_name = Team.objects.filter(name=self.cleaned_data.get('name')).exclude(pk=self.instance.pk)
                     if existing_team_with_name:
                         raise ValidationError(('Invalid value for name. A team already exists with that name.'),
@@ -200,8 +199,8 @@ class OrganizerTeamsCSVForm(forms.Form):
             temp_csv = self.cleaned_data.get('csv_file')
             csv_team_list = [line.rstrip() for line in temp_csv]
             for index, value in enumerate(csv_team_list):
-                temp_line = value.replace(' ', '').split(',')
-                # Pop the team name (First value), into the dict key, then the rest of the list is users.
+                temp_line = value.split(',')
+                temp_line = [s.strip() for s in temp_line]
                 teams_dict[temp_line.pop(0)] = temp_line
         self.teams_dict = teams_dict
 

--- a/codalab/apps/teams/models.py
+++ b/codalab/apps/teams/models.py
@@ -90,23 +90,6 @@ def get_allowed_teams(user,competition):
 
 
 def get_user_team(user, competition):
-    # team = get_competition_user_teams(competition, user)
-    #
-    # if team is not None:
-    #     return team
-    #
-    # user_requests = get_user_requests(user, competition)
-    # user_team = user_requests.filter(status=TeamMembershipStatus.objects.get(codename="approved")).all()
-    # if len(user_team) == 0:
-    #     user_team = None
-    #
-    # if user_team is not None:
-    #     for req in user_team:
-    #         if req.is_active:
-    #             team = req
-    #
-    # if team is not None:
-    #     team = team.team
     membership = TeamMembership.objects.filter(user=user, team__competition=competition).first()
     if membership:
         return membership.team

--- a/codalab/apps/teams/models.py
+++ b/codalab/apps/teams/models.py
@@ -90,25 +90,26 @@ def get_allowed_teams(user,competition):
 
 
 def get_user_team(user, competition):
-    team = get_competition_user_teams(competition, user)
-
-    if team is not None:
-        return team
-
-    user_requests = get_user_requests(user, competition)
-    user_team = user_requests.filter(status=TeamMembershipStatus.objects.get(codename="approved")).all()
-    if len(user_team) == 0:
-        user_team = None
-
-    if user_team is not None:
-        for req in user_team:
-            if req.is_active:
-                team = req
-
-    if team is not None:
-        team = team.team
-
-    return team
+    # team = get_competition_user_teams(competition, user)
+    #
+    # if team is not None:
+    #     return team
+    #
+    # user_requests = get_user_requests(user, competition)
+    # user_team = user_requests.filter(status=TeamMembershipStatus.objects.get(codename="approved")).all()
+    # if len(user_team) == 0:
+    #     user_team = None
+    #
+    # if user_team is not None:
+    #     for req in user_team:
+    #         if req.is_active:
+    #             team = req
+    #
+    # if team is not None:
+    #     team = team.team
+    membership = TeamMembership.objects.filter(user=user, team__competition=competition).first()
+    if membership:
+        return membership.team
 
 
 def get_team_submissions(team, phase=None):

--- a/codalab/apps/teams/models.py
+++ b/codalab/apps/teams/models.py
@@ -201,7 +201,7 @@ class Team(models.Model):
     image_url_base = models.CharField(max_length=255)
     allow_requests = models.BooleanField(default=True, verbose_name="Allow requests")
     creator = models.ForeignKey(settings.AUTH_USER_MODEL, related_name='team_creator')
-    members = models.ManyToManyField(settings.AUTH_USER_MODEL, through='TeamMembership', blank=True, null=True)
+    members = models.ManyToManyField(settings.AUTH_USER_MODEL, through='TeamMembership', blank=True, null=True, related_name='teams')
     created_at = models.DateTimeField(null=True, auto_now_add=True)
     last_modified = models.DateTimeField(auto_now_add=True)
     status = models.ForeignKey(TeamStatus, null=True)
@@ -283,18 +283,6 @@ class TeamMembershipStatus(models.Model):
 
 
 class TeamMembership(models.Model):
-    def __unicode__(self):
-        return "%s - %s" % (self.team_id, self.user_id)
-
-    @property
-    def is_active(self):
-        if self.start_date is not None and now() < self.start_date:
-            return False
-        if self.end_date is not None and now() > self.end_date:
-            return False
-
-        return True
-
     user = models.ForeignKey(settings.AUTH_USER_MODEL)
     team = models.ForeignKey(Team)
     is_invitation = models.BooleanField(default=False)
@@ -304,3 +292,27 @@ class TeamMembership(models.Model):
     message = models.TextField(null=True, blank=True)
     status = models.ForeignKey(TeamMembershipStatus, null=True)
     reason = models.CharField(max_length=100,null=True,blank=True)
+
+    def __unicode__(self):
+        return "%s - %s" % (self.team_id, self.user_id)
+
+    def save(self, force_insert=False, force_update=False, using=None, update_fields=None):
+        other_memberships = TeamMembership.objects.filter(user=self.user, team__competition=self.team.competition).exclude(pk=self.pk)
+        if len(other_memberships) != 0:
+            print("Removing user: {0} from other memberships in competition: {1}".format(self.user, self.team.competition))
+            other_memberships.delete()
+        super(TeamMembership, self).save(
+            force_insert=force_insert,
+            force_update=force_update,
+            using=using,
+            update_fields=update_fields
+        )
+
+    @property
+    def is_active(self):
+        if self.start_date is not None and now() < self.start_date:
+            return False
+        if self.end_date is not None and now() > self.end_date:
+            return False
+
+        return True

--- a/codalab/apps/teams/templates/teams/competitions/organizer_csv_teams.html
+++ b/codalab/apps/teams/templates/teams/competitions/organizer_csv_teams.html
@@ -12,12 +12,13 @@
 
 {% block content %}
 
-<a href="{% url "competitions:view" pk=competition.pk %}" class="pull-right" >Go Back to Competition Homepage</a>
-
-    <form action="" method="post">
+    <a href="{% url "competitions:view" pk=competition.pk %}" class="pull-right">Go Back to Competition Homepage</a>
+    {{ csv_form.non_field_errors }}
+    <form action="{% url "create_org_teams_from_csv" competition_pk=competition.pk %}" method="POST" enctype="multipart/form-data">
         {% csrf_token %}
-        {{ my_form.as_p }}
+        {{ form.as_p }}
         <input type="submit" value="Submit">
     </form>
+
 
 {% endblock %}

--- a/codalab/apps/teams/templates/teams/competitions/organizer_csv_teams.html
+++ b/codalab/apps/teams/templates/teams/competitions/organizer_csv_teams.html
@@ -11,8 +11,8 @@
 {% endblock %}
 
 {% block content %}
-    <a href="{% url "competitions:view" pk=competition.pk %}" class="pull-right">Go Back to Competition Homepage</a>
-    {{ csv_form.non_field_errors }}
+    <a href="{% url "competitions:view" pk=form.competition.pk %}" class="pull-right">Go Back to Competition Homepage</a>
+    {{ form.non_field_errors }}
     <div id="main_container" class="container-fluid">
     <form id="choose-file" action="{% url "create_org_teams_from_csv" competition_pk=competition.pk %}" method="POST" enctype="multipart/form-data">
         {% csrf_token %}

--- a/codalab/apps/teams/templates/teams/competitions/organizer_csv_teams.html
+++ b/codalab/apps/teams/templates/teams/competitions/organizer_csv_teams.html
@@ -11,7 +11,6 @@
 {% endblock %}
 
 {% block content %}
-
     <a href="{% url "competitions:view" pk=competition.pk %}" class="pull-right">Go Back to Competition Homepage</a>
     {{ csv_form.non_field_errors }}
     <div id="main_container" class="container-fluid">

--- a/codalab/apps/teams/templates/teams/competitions/organizer_csv_teams.html
+++ b/codalab/apps/teams/templates/teams/competitions/organizer_csv_teams.html
@@ -11,7 +11,7 @@
 {% endblock %}
 
 {% block content %}
-    <a href="{% url "competitions:view" pk=form.competition.pk %}" class="pull-right">Go Back to Competition Homepage</a>
+    <a href="{% url "competitions:view" pk=competition.pk %}" class="pull-right">Go Back to Competition Homepage</a>
     {{ form.non_field_errors }}
     <div id="main_container" class="container-fluid">
     <form id="choose-file" action="{% url "create_org_teams_from_csv" competition_pk=competition.pk %}" method="POST" enctype="multipart/form-data">

--- a/codalab/apps/teams/templates/teams/competitions/organizer_csv_teams.html
+++ b/codalab/apps/teams/templates/teams/competitions/organizer_csv_teams.html
@@ -14,11 +14,115 @@
 
     <a href="{% url "competitions:view" pk=competition.pk %}" class="pull-right">Go Back to Competition Homepage</a>
     {{ csv_form.non_field_errors }}
-    <form action="{% url "create_org_teams_from_csv" competition_pk=competition.pk %}" method="POST" enctype="multipart/form-data">
+    <div id="main_container" class="container-fluid">
+    <form id="choose-file" action="{% url "create_org_teams_from_csv" competition_pk=competition.pk %}" method="POST" enctype="multipart/form-data">
         {% csrf_token %}
         {{ form.as_p }}
-        <input type="submit" value="Submit">
-    </form>
-
-
+        <div id="panel_container" class="panel panel-default">
+            <div id="info_container">The CSV File should be formatted with the teams in each row, where the team name is
+                the first entry, and team members are separated by commas.
+            </div>
+        <button id="submit_button" type="button" class="pull-middle btn btn-primary">Submit Teams from CSV</button>
+            <div id="code">
+                Example CSV:
+                <table>
+                    <tr>
+                        <td>TeamOne, Team Member 1, Team Member 2, Team Member 3,<br/>TeamTwo, Team Member 1, Team Member 2</td>
+                    </tr>
+                </table>
+            </div>
+        </div>
+        </form>
+    </div>
+<style>
+    #main_container {
+        text-align: center;
+        margin: auto;
+        padding: 3em;
+    }
+    #code {
+        border:solid gray;
+        border-width:.1em .1em .1em .8em;
+        padding:.2em .6em;
+        overflow: auto;
+        width: 70%;
+        margin: auto;
+        text-align: left;
+        background: #f0f0f0;
+        font-family: Monospace;
+    }
+    table {
+        text-align: left;
+        width: 100%;
+        background: #f0f0f0;
+    }
+    #panel_container {
+        margin: auto;
+        width: inherit;
+        padding-bottom: 6em;
+        padding-top: 4em;
+        text-align: center;
+    }
+    #info_container {
+        width: 90%;
+        font-size: 19px;
+        margin: auto;
+        height: 4em;
+    }
+    #choose-file>p {
+        display: none;
+    }
+    #submit_button {
+        margin: 1em auto;
+    }
+    @media only screen and (max-width: 991px) {
+        #info_container {
+            font-size: 15px;
+            height: 5em;
+        }
+        #code {
+            width: auto;
+        }
+    }
+    @media only screen and (max-width: 671px) {
+        #code {
+            font-size: 13px;
+            width: auto;
+        }
+    }
+    @media only screen and (max-width: 570px) {
+        #code {
+            font-size: 11px;
+            width: auto;
+        }
+    }
+    @media only screen and (max-width: 477px) {
+        #info_container {
+            font-size: 13px;
+            height: 5em;
+        }
+    }
+</style>
+<script>
+    $( document ).ready(function() {
+        $("#submit_button").click(function () {
+            $('#id_csv_file').click();
+        });
+        $('#id_csv_file').change(function(){
+            $('#choose-file').submit()
+        });
+        var errors = document.getElementsByClassName("errorlist");
+        if (errors[0].innerText !== ""){
+            errors[0].classList.add('list-unstyled');
+            errors[0].children[0].classList.add('alert');
+            errors[0].children[0].classList.add('alert-danger');
+            $('.alert.alert-danger').css({
+                'margin': '2em auto 0 auto',
+                'text-align': 'center',
+                'border-radius': '4px',
+                'width': '50%'
+        })
+        }
+    });
+</script>
 {% endblock %}

--- a/codalab/apps/teams/templates/teams/competitions/organizer_teams.html
+++ b/codalab/apps/teams/templates/teams/competitions/organizer_teams.html
@@ -12,24 +12,27 @@
 
 {% block content %}
     <div id="comp-back">
-        <a href="{% url "competitions:view" pk=competition.pk %}" class="pull-right">Go Back to Competition Homepage</a>
+        <a href="{% url "competitions:view" pk=form.competition.pk %}" class="pull-right">Go Back to Competition Homepage</a>
     </div>
     <div id="main_container" class="container-fluid">
-        {{ csv_form.non_field_errors }}
+        {{ form.non_field_errors }}
         <form action="" method="post" enctype="multipart/form-data">
             {% csrf_token %}
             <div id="panel_container" class="panel panel-default">
                 <div class="form-group">
                     <label for="id_name">Team Name:</label>
-                    <input id="id_name" maxlength="100" name="name" type="text"/>
+                    <input id="id_name" maxlength="100" name="name" type="text" value="{{ form.name.value|default_if_none:"" }}"/>
+                    <p>{{ form.name.errors }}</p>
                 </div>
                 <div class="form-group">
                     <label for="id_text_members">Team Members:</label>
-                    <textarea class="form-control" rows="3" id="id_text_members" name="text_members" placeholder="Enter team member names separated by commas. (Ex. Team Member1, Team Member 2, etc.)"></textarea>
+                    <textarea class="form-control" rows="3" id="id_text_members" name="text_members" placeholder="Enter team member names separated by commas. (Ex. Team Member1, Team Member 2, etc.)">{{ initial_team_members|default_if_none:"" }}</textarea>
+                    <p>{{ form.text_members.error }}</p>
                 </div>
                 <div class="form-group">
                     <label for="id_description">Description:</label>
-                    <textarea class="form-control" rows="3" id="id_description" name="description" placeholder="Enter a short description of the team here."></textarea>
+                    <textarea class="form-control" rows="3" id="id_description" name="description" placeholder="Enter a short description of the team here.">{{ form.description.value|default_if_none:"" }}</textarea>
+                    <p>{{ form.description.error }}</p>
                 </div>
                 <div id="pull-middle">
                     <input id="submit_button" type="submit" class="pull-middle btn btn-primary" value="Submit Team">

--- a/codalab/apps/teams/templates/teams/competitions/organizer_teams.html
+++ b/codalab/apps/teams/templates/teams/competitions/organizer_teams.html
@@ -1,0 +1,23 @@
+{% extends 'base.html' %}
+{% load staticfiles %}
+{% load codalab_tags %}
+{% load tz %}
+
+{% block page_title %}Participants{% endblock page_title %}
+{% block head_title %}Participants{% endblock %}
+
+{% block extra_head %}
+    <script src="{% static 'js/foundation/vendor/jquery.validate.min.js' %}"></script>
+{% endblock %}
+
+{% block content %}
+
+    <a href="{% url "competitions:view" pk=competition.pk %}" class="pull-right">Go Back to Competition Homepage</a>
+    <form action="" method="post" enctype="multipart/form-data">
+        {% csrf_token %}
+        {{ form.as_p }}
+        <input type="submit" value="Submit">
+    </form>
+
+
+{% endblock %}

--- a/codalab/apps/teams/templates/teams/competitions/organizer_teams.html
+++ b/codalab/apps/teams/templates/teams/competitions/organizer_teams.html
@@ -11,13 +11,56 @@
 {% endblock %}
 
 {% block content %}
-
-    <a href="{% url "competitions:view" pk=competition.pk %}" class="pull-right">Go Back to Competition Homepage</a>
-    <form action="" method="post" enctype="multipart/form-data">
-        {% csrf_token %}
-        {{ form.as_p }}
-        <input type="submit" value="Submit">
-    </form>
-
-
+    <div id="comp-back">
+        <a href="{% url "competitions:view" pk=competition.pk %}" class="pull-right">Go Back to Competition Homepage</a>
+    </div>
+    <div id="main_container" class="container-fluid">
+        {{ csv_form.non_field_errors }}
+        <form action="" method="post" enctype="multipart/form-data">
+            {% csrf_token %}
+            <div id="panel_container" class="panel panel-default">
+                <div class="form-group">
+                    <label for="id_name">Team Name:</label>
+                    <input id="id_name" maxlength="100" name="name" type="text"/>
+                </div>
+                <div class="form-group">
+                    <label for="id_text_members">Team Members:</label>
+                    <textarea class="form-control" rows="3" id="id_text_members" name="text_members" placeholder="Enter team member names separated by commas. (Ex. Team Member1, Team Member 2, etc.)"></textarea>
+                </div>
+                <div class="form-group">
+                    <label for="id_description">Description:</label>
+                    <textarea class="form-control" rows="3" id="id_description" name="description" placeholder="Enter a short description of the team here."></textarea>
+                </div>
+                <div id="pull-middle">
+                    <input id="submit_button" type="submit" class="pull-middle btn btn-primary" value="Submit Team">
+                </div>
+            </div>
+        </form>
+    </div>
+    <style>
+        #main_container {
+            text-align: left;
+            margin: 0 auto;
+            padding: 1em;
+        }
+        #id_name {
+            width: 40%;
+        }
+        .form-group {
+            width: 96%;
+            margin: 0.5em auto;
+        }
+        #panel_container {
+            margin: 1em auto;
+            width: 80%;
+            padding-bottom: 2em;
+            padding-top: 1em;
+        }
+        #pull-middle {
+            text-align: center;
+        }
+        #submit_button {
+            margin: 1em auto;
+        }
+    </style>
 {% endblock %}

--- a/codalab/apps/teams/tests/test_organizer_teams.py
+++ b/codalab/apps/teams/tests/test_organizer_teams.py
@@ -5,7 +5,7 @@ from django.contrib.auth import get_user_model
 from django.core.urlresolvers import reverse
 
 from apps.web.models import Competition
-from apps.teams.models import Team
+from apps.teams.models import Team, TeamStatus
 
 User = get_user_model()
 
@@ -32,34 +32,64 @@ class CompetitionOrganizerTeamsTests(TestCase):
     def test_organizer_teams_competition_creator_can_create_teams(self):
         # Creator and Admin should be allowed.
         self.client.login(username='testuser', password='test')
-        resp = self.client.post(reverse('create_org_team', kwargs={'competition_pk': self.competition.pk}), {"text_members": "test@user.com", "name": "Test Team 1", "description": "Test Team"})
+
+        resp = self.client.post(
+            reverse('create_org_team', kwargs={
+                'competition_pk': self.competition.pk
+            }),
+            {"text_members": "test@user.com", "name": "Test Team 1", "description": "Test Team"}
+        )
+
         assert resp.status_code == 302
         assert resp.url == 'http://testserver/my/competition/1/participants/'
 
-    def test_organizer_teams_sitewide_admin_can_create_teams(self):
+    def test_organizer_teams_competition_admin_can_create_teams(self):
         self.client.login(username='testadminuser', password='testadmin')
-        resp = self.client.post(reverse('create_org_team', kwargs={'competition_pk': self.competition.pk}),
-                          {"text_members": "testadmin@user.com", "name": "Test Team 3", "description": "Test Team"})
+
+        resp = self.client.post(
+            reverse('create_org_team', kwargs={
+                'competition_pk': self.competition.pk
+            }),
+            {"text_members": "testadmin@user.com", "name": "Test Team 3", "description": "Test Team"}
+        )
+
         assert resp.status_code == 302
         assert resp.url == 'http://testserver/my/competition/1/participants/'
 
     def test_organizer_teams_regular_user_cannot_create_teams(self):
         # Random users should not be allowed, nor anonymous users
         self.client.login(username='testclientuser', password='testclient')
-        resp = self.client.post(reverse('create_org_team', kwargs={'competition_pk': self.competition.pk}),
-                      {"text_members": "testclient@user.com", "name": "Test Team 2", "description": "Test Team"})
+
+        resp = self.client.post(
+            reverse('create_org_team', kwargs={
+                'competition_pk': self.competition.pk
+            }),
+            {"text_members": "testclient@user.com", "name": "Test Team 2", "description": "Test Team"}
+        )
+
         assert resp.status_code == 403
 
     def test_organizer_teams_random_user_cannot_create_teams(self):
-        resp = self.client.post(reverse('create_org_team', kwargs={'competition_pk': self.competition.pk}),
-                         {"text_members": "testadmin@user.com", "name": "Test Team 4", "description": "Test Team"})
+        resp = self.client.post(
+            reverse('create_org_team', kwargs={
+                'competition_pk': self.competition.pk
+            }),
+            {"text_members": "testadmin@user.com", "name": "Test Team 4", "description": "Test Team"}
+        )
+
         assert resp.status_code == 302
         assert resp.url == 'http://testserver/accounts/login/?next=/teams/1/create_org_team/'
 
     def test_organizer_team_form_with_creator(self):
         self.client.login(username='testuser', password='test')
-        resp = self.client.post(reverse('create_org_team', kwargs={'competition_pk': self.competition.pk}),
-                            {"text_members": "test@user.com", "name": "Test Team 1", "description": "Test Team"})
+
+        resp = self.client.post(
+            reverse('create_org_team', kwargs={
+                'competition_pk': self.competition.pk
+            }),
+            {"text_members": "test@user.com", "name": "Test Team 1", "description": "Test Team"}
+        )
+
         assert resp.status_code == 302
         # Make sure new team was created
         new_team = Team.objects.get(name="Test Team 1", description="Test Team")
@@ -67,10 +97,9 @@ class CompetitionOrganizerTeamsTests(TestCase):
         assert self.creator in new_team.members.all()
 
         resp = self.client.post(
-            reverse(
-                'edit_org_team',
-                kwargs={'competition_pk': self.competition.pk, 'pk': new_team.pk}
-            ),
+            reverse('edit_org_team',kwargs={
+                'competition_pk': self.competition.pk, 'pk': new_team.pk
+            }),
             {"text_members": "test@user.com", "name": "Test Team 1", "description": "Test Team"}
         )
 
@@ -82,10 +111,9 @@ class CompetitionOrganizerTeamsTests(TestCase):
         new_team = Team.objects.get(name="Test Team 1", description="Test Team")
 
         resp = self.client.post(
-            reverse(
-                'edit_org_team',
-                kwargs={'competition_pk': self.competition.pk, 'pk': new_team.pk}
-            ),
+            reverse('edit_org_team', kwargs={
+                'competition_pk': self.competition.pk, 'pk': new_team.pk
+            }),
             {"text_members": "test@user.com", "name": "Test Team @@@", "description": "Test Team @@@"}
         )
 
@@ -96,10 +124,9 @@ class CompetitionOrganizerTeamsTests(TestCase):
         assert self.creator in new_team.members.all()
 
         resp = self.client.post(
-            reverse(
-                'edit_org_team',
-                kwargs={'competition_pk': self.competition.pk, 'pk': new_team.pk}
-            ),
+            reverse('edit_org_team',kwargs={
+                'competition_pk': self.competition.pk, 'pk': new_team.pk
+            }),
             {"text_members": "test@user.com, testclientuser", "name": "Test Team @@@", "description": "Test Team @@@"}
         )
 
@@ -111,8 +138,13 @@ class CompetitionOrganizerTeamsTests(TestCase):
         assert self.user in new_team.members.all()
 
         # Create a new team with our creator as a member. This should remove us from the first team.
-        resp = self.client.post(reverse('create_org_team', kwargs={'competition_pk': self.competition.pk}),
-                            {"text_members": "test@user.com", "name": "@@@Test@@@", "description": "@@@Test@@@"})
+        resp = self.client.post(
+            reverse('create_org_team', kwargs={
+                'competition_pk': self.competition.pk
+            }),
+            {"text_members": "test@user.com", "name": "@@@Test@@@", "description": "@@@Test@@@"}
+        )
+
         assert resp.status_code == 302
         new_team_to_leave_for = Team.objects.get(name="@@@Test@@@", description="@@@Test@@@")
         # Check that our creator got removed from the first team, and added to the second.
@@ -128,8 +160,11 @@ class CompetitionOrganizerTeamsTests(TestCase):
 
         creator = self.client
         creator.login(username='testuser', password='test')
+
         resp = creator.post(
-            reverse('create_org_teams_from_csv', kwargs={'competition_pk': self.competition.pk}),
+            reverse('create_org_teams_from_csv', kwargs={
+                'competition_pk': self.competition.pk
+            }),
             {"csv_file": test_csv}
         )
         assert resp.status_code == 302
@@ -143,10 +178,9 @@ class CompetitionOrganizerTeamsTests(TestCase):
         assert self.creator in new_team.members.all()
 
         resp = creator.post(
-            reverse(
-                'edit_org_team',
-                kwargs={'competition_pk': self.competition.pk, 'pk': new_team.pk}
-            ),
+            reverse('edit_org_team', kwargs={
+                'competition_pk': self.competition.pk, 'pk': new_team.pk
+            }),
             {"text_members": "test@user.com, testclientuser", "name": "Test Team @@@", "description": "Test Team @@@"}
         )
 
@@ -159,19 +193,172 @@ class CompetitionOrganizerTeamsTests(TestCase):
 
         test_csv_two = SimpleUploadedFile(
             "test_team.csv",
-            "Team1, test@user.com, team_member2, team_member3\n",
+            "Team 1, test@user.com, team_member2, team_member3\n",
             content_type='multipart/form-data'
         )
 
         resp = creator.post(
-            reverse('create_org_teams_from_csv', kwargs={'competition_pk': self.competition.pk}),
+            reverse('create_org_teams_from_csv', kwargs={
+                'competition_pk': self.competition.pk
+            }),
             {"csv_file": test_csv_two}
         )
+
+        assert resp.status_code == 302
+        assert resp.url == 'http://testserver/my/competition/1/participants/'
+
+        new_team = Team.objects.get(name="Team 1", description="Team 1")
+        # Make sure we can grab it by the new name and description.
+        # We should still have the creator as a member
+        assert self.creator in new_team.members.all()
+
+        test_csv_three = SimpleUploadedFile(
+            "test_team.csv",
+            "Team 1, test@user.com, team_member2, team_member3\n",
+            content_type='multipart/form-data'
+        )
+
+        resp = creator.post(
+            reverse('create_org_teams_from_csv', kwargs={
+                'competition_pk': self.competition.pk
+            }),
+            {"csv_file": test_csv_three}
+        )
+
         assert resp.status_code == 302
         assert resp.url == 'http://testserver/my/competition/1/participants/'
 
         # Spaces will be removed from the name!
-        new_team = Team.objects.get(name="Team1", description="Team1")
+        new_team = Team.objects.get(name="Team 1", description="Team 1")
         # Make sure we can grab it by the new name and description.
         # We should still have the creator as a member
         assert self.creator in new_team.members.all()
+
+    def test_organizer_teams_competition_creator_can_delete_teams(self):
+        new_team = Team.objects.create(
+            name="Test Team!", description="Test Team!",
+            competition=self.competition,
+            creator=self.creator,
+            allow_requests=False,
+            status=TeamStatus.objects.get(codename=TeamStatus.APPROVED)
+        )
+
+        self.client.login(username='testuser', password='test')
+
+        resp = self.client.post(
+            reverse(
+                'delete_org_team',
+                kwargs={
+                    'competition_pk': self.competition.pk,
+                    'team_pk': new_team.pk
+                }
+            )
+        )
+
+        assert resp.status_code == 302
+        assert resp.url == 'http://testserver/my/competition/1/participants/'
+
+    def test_organizer_teams_competition_admin_can_delete_teams(self):
+        new_team = Team.objects.create(
+            name="Test Team!", description="Test Team!",
+            competition=self.competition,
+            creator=self.creator,
+            allow_requests=False,
+            status=TeamStatus.objects.get(codename=TeamStatus.APPROVED)
+        )
+
+        self.client.login(username='testadminuser', password='testadmin')
+
+        resp = self.client.post(
+            reverse(
+                'delete_org_team',
+                kwargs={
+                    'competition_pk': self.competition.pk,
+                    'team_pk': new_team.pk
+                }
+            )
+        )
+
+        assert resp.status_code == 302
+        assert resp.url == 'http://testserver/my/competition/1/participants/'
+
+    def test_organizer_teams_regular_user_cannot_delete_teams(self):
+        new_team = Team.objects.create(
+            name="Test Team!", description="Test Team!",
+            competition=self.competition,
+            creator=self.creator,
+            allow_requests=False,
+            status=TeamStatus.objects.get(codename=TeamStatus.APPROVED)
+        )
+
+        self.client.login(username='testclientuser', password='testclient')
+
+        resp = self.client.post(
+            reverse(
+                'delete_org_team',
+                kwargs={
+                    'competition_pk': self.competition.pk,
+                    'team_pk': new_team.pk
+                }
+            )
+        )
+
+        assert resp.status_code == 403
+
+    def test_organizer_teams_random_user_cannot_delete_teams(self):
+        new_team = Team.objects.create(
+            name="Test Team!", description="Test Team!",
+            competition=self.competition,
+            creator=self.creator,
+            allow_requests=False,
+            status=TeamStatus.objects.get(codename=TeamStatus.APPROVED)
+        )
+
+        resp = self.client.post(
+            reverse(
+                'delete_org_team',
+                kwargs={
+                    'competition_pk': self.competition.pk,
+                    'team_pk': new_team.pk
+                }
+            )
+        )
+
+        assert resp.status_code == 302
+        assert resp.url == 'http://testserver/accounts/login/?next=/teams/1/delete_org_team/1'
+
+    def test_organizer_teams_test_allowed_methods_for_delete(self):
+        new_team = Team.objects.create(
+            name="Test Team!", description="Test Team!",
+            competition=self.competition,
+            creator=self.creator,
+            allow_requests=False,
+            status=TeamStatus.objects.get(codename=TeamStatus.APPROVED)
+        )
+
+        self.client.login(username='testuser', password='test')
+
+        resp = self.client.get(
+            reverse(
+                'delete_org_team',
+                kwargs={
+                    'competition_pk': self.competition.pk,
+                    'team_pk': new_team.pk
+                }
+            )
+        )
+
+        assert resp.status_code == 405
+
+        resp = self.client.post(
+            reverse(
+                'delete_org_team',
+                kwargs={
+                    'competition_pk': self.competition.pk,
+                    'team_pk': new_team.pk
+                }
+            )
+        )
+
+        assert resp.status_code == 302
+        assert resp.url == 'http://testserver/my/competition/1/participants/'

--- a/codalab/apps/teams/tests/test_organizer_teams.py
+++ b/codalab/apps/teams/tests/test_organizer_teams.py
@@ -170,7 +170,6 @@ class CompetitionOrganizerTeamsTests(TestCase):
         assert resp.status_code == 302
         assert resp.url == 'http://testserver/my/competition/1/participants/'
 
-        # Spaces will be removed from the name!
         new_team = Team.objects.get(name="Team 1", description="Team 1")
         print("NEW MEMBERS: {}".format(new_team.members.all()))
         # Make sure we can grab it by the new name and description.
@@ -214,7 +213,7 @@ class CompetitionOrganizerTeamsTests(TestCase):
 
         test_csv_three = SimpleUploadedFile(
             "test_team.csv",
-            "Team 1, test@user.com, team_member2, team_member3\n",
+            "Team 1, team_member2, team_member3\n",
             content_type='multipart/form-data'
         )
 
@@ -228,11 +227,10 @@ class CompetitionOrganizerTeamsTests(TestCase):
         assert resp.status_code == 302
         assert resp.url == 'http://testserver/my/competition/1/participants/'
 
-        # Spaces will be removed from the name!
         new_team = Team.objects.get(name="Team 1", description="Team 1")
         # Make sure we can grab it by the new name and description.
-        # We should still have the creator as a member
-        assert self.creator in new_team.members.all()
+        # We should not have the creator as a member
+        assert self.creator not in new_team.members.all()
 
     def test_organizer_teams_competition_creator_can_delete_teams(self):
         new_team = Team.objects.create(

--- a/codalab/apps/teams/tests/test_organizer_teams.py
+++ b/codalab/apps/teams/tests/test_organizer_teams.py
@@ -28,7 +28,7 @@ class CompetitionPhaseToPhase(TestCase):
         self.competition.admins.add(self.admin)
         self.competition.save()
 
-    def test_submit_organizer_team_form(self):
+    def test_who_can_create_organizer_teams(self):
         creator = Client()
         creator.login(username='testuser', password='test')
         resp = creator.post(reverse('create_org_team', kwargs={'competition_pk': self.competition.pk}), {"text_members": "test@user.com", "name": "Test Team 1", "description": "Test Team"})

--- a/codalab/apps/teams/tests/test_organizer_teams.py
+++ b/codalab/apps/teams/tests/test_organizer_teams.py
@@ -1,0 +1,53 @@
+import datetime
+
+from django.test import TestCase, Client
+from django.contrib.auth import get_user_model
+from django.core.urlresolvers import reverse
+from django.utils.timezone import now
+
+from apps.web.models import Competition, CompetitionParticipant, CompetitionPhase, ParticipantStatus
+
+User = get_user_model()
+
+
+class CompetitionPhaseToPhase(TestCase):
+    def setUp(self):
+        self.creator = User.objects.create(email='test@user.com', username='testuser')
+        self.creator.set_password('test')
+        self.creator.save()
+
+        self.admin = User.objects.create(email='testadmin@user.com', username='testadminuser')
+        self.admin.set_password('testadmin')
+        self.admin.save()
+
+        self.user = User.objects.create(email='testclient@user.com', username='testclientuser')
+        self.user.set_password('testclient')
+        self.user.save()
+
+        self.competition = Competition.objects.create(creator=self.creator, modified_by=self.creator)
+        self.competition.admins.add(self.admin)
+        self.competition.save()
+
+    def test_submit_organizer_team_form(self):
+        creator = Client()
+        creator.login(username='testuser', password='test')
+        resp = creator.post(reverse('create_org_team', kwargs={'competition_pk': self.competition.pk}), {"text_members": "test@user.com", "name": "Test Team 1", "description": "Test Team"})
+        assert(resp.status_code == 302)
+
+        user = Client()
+        user.login(username='testclientuser', password='testclient')
+        resp = user.post(reverse('create_org_team', kwargs={'competition_pk': self.competition.pk}),
+                      {"text_members": "testclient@user.com", "name": "Test Team 2", "description": "Test Team"})
+        assert (resp.status_code == 403)
+
+        admin = Client()
+        admin.login(username='testadminuser', password='testadmin')
+        resp = admin.post(reverse('create_org_team', kwargs={'competition_pk': self.competition.pk}),
+                         {"text_members": "testadmin@user.com", "name": "Test Team 3", "description": "Test Team"})
+        assert (resp.status_code == 302)
+
+        anon = Client()
+        # admin.login(username='testadminuser', password='testadmin')
+        resp = anon.post(reverse('create_org_team', kwargs={'competition_pk': self.competition.pk}),
+                         {"text_members": "testadmin@user.com", "name": "Test Team 4", "description": "Test Team"})
+        assert (resp.url == 'http://testserver/accounts/login/?next=/teams/1/create_org_team/')

--- a/codalab/apps/teams/urls.py
+++ b/codalab/apps/teams/urls.py
@@ -10,4 +10,8 @@ urlpatterns = patterns('',
     url(r'^(?P<competition_pk>\d+)/(?P<team_pk>\d+)/delete/$', views.TeamCancelView.as_view(), name='team_delete'),
     url(r'^(?P<competition_pk>\d+)/(?P<request_pk>\d+)/(?P<action>accept|reject|cancel)/$', views.RequestTeamView.as_view(), name='team_request_action'),
     url(r'^(?P<competition_pk>\d+)/request/(?P<team_pk>\d+)/$', views.NewRequestTeamView.as_view(), name='team_enrol'),
+    url(r'^(?P<competition_pk>\d+)/create_org_team/$', views.CompetitionOrganizerTeams.as_view(), name='create_org_team'),
+    url(r'^(?P<competition_pk>\d+)/create_org_teams_from_csv/$', views.CompetitionOrganizerCSVTeams.as_view(), name='create_org_teams_from_csv'),
+    url(r'^(?P<competition_pk>\d+)/edit_org_team/(?P<pk>\d+)$', views.CompetitionOrganizerTeams.as_view(), name='edit_org_team'),
+    url(r'^(?P<competition_pk>\d+)/delete_org_team/(?P<team_pk>\d+)$', views.delete_organizer_team, name='delete_org_team'),
 )

--- a/codalab/apps/teams/views.py
+++ b/codalab/apps/teams/views.py
@@ -337,8 +337,6 @@ class CompetitionOrganizerTeams(FormView):
         if self.request.user != competition.creator:
             if self.request.user not in competition.admins.all():
                 return HttpResponseForbidden(status=403)
-            else:
-                pass
         return super(CompetitionOrganizerTeams, self).dispatch(*args, **kwargs)
 
     def get_form(self, form_class=None):
@@ -401,8 +399,6 @@ class CompetitionOrganizerCSVTeams(FormView):
         if self.request.user != competition.creator:
             if self.request.user not in competition.admins.all():
                 return HttpResponseForbidden(status=403)
-            else:
-                pass
         return super(CompetitionOrganizerCSVTeams, self).dispatch(*args, **kwargs)
 
     # success_url = reverse('competitions:participants')

--- a/codalab/apps/teams/views.py
+++ b/codalab/apps/teams/views.py
@@ -333,6 +333,12 @@ class CompetitionOrganizerTeams(FormView):
 
     @method_decorator(login_required)
     def dispatch(self, *args, **kwargs):
+        competition = Competition.objects.get(pk=self.kwargs['competition_pk'])
+        if self.request.user != competition.creator:
+            if self.request.user not in competition.admins.all():
+                return HttpResponseForbidden(status=403)
+            else:
+                pass
         return super(CompetitionOrganizerTeams, self).dispatch(*args, **kwargs)
 
     def get_form(self, form_class=None):
@@ -391,6 +397,12 @@ class CompetitionOrganizerCSVTeams(FormView):
 
     @method_decorator(login_required)
     def dispatch(self, *args, **kwargs):
+        competition = Competition.objects.get(pk=self.kwargs['competition_pk'])
+        if self.request.user != competition.creator:
+            if self.request.user not in competition.admins.all():
+                return HttpResponseForbidden(status=403)
+            else:
+                pass
         return super(CompetitionOrganizerCSVTeams, self).dispatch(*args, **kwargs)
 
     # success_url = reverse('competitions:participants')

--- a/codalab/apps/teams/views.py
+++ b/codalab/apps/teams/views.py
@@ -1,3 +1,7 @@
+from django.contrib.auth.decorators import login_required
+from django.core.exceptions import ObjectDoesNotExist
+from django.shortcuts import redirect
+from django.utils.decorators import method_decorator
 from django.utils.timezone import now
 from django.contrib.auth import get_user_model
 from django.core.urlresolvers import reverse
@@ -7,8 +11,9 @@ from apps.web.views import LoginRequiredMixin
 
 from .models import Team, TeamStatus, TeamMembership, TeamMembershipStatus, get_user_requests, get_competition_teams, get_user_team, get_allowed_teams, get_team_pending_membership, get_competition_user_pending_teams, get_team_submissions_inf
 from apps.teams import forms
+from apps.teams.forms import OrganizerTeamForm, OrganizerTeamsCSVForm
 from django.views.generic import View, TemplateView, DetailView, ListView, FormView, UpdateView, CreateView, DeleteView
-from django.http import Http404, QueryDict
+from django.http import Http404, QueryDict, HttpResponseForbidden, HttpResponse
 
 User = get_user_model()
 
@@ -318,4 +323,94 @@ class TeamCancelView(TeamDetailView):
         if error is not None:
             context['error'] = error
         context['team'] = team
+        return context
+
+
+# @login_required
+class CompetitionOrganizerTeams(FormView):
+    form_class = OrganizerTeamForm
+    template_name = 'teams/competitions/organizer_teams.html'
+
+    @method_decorator(login_required)
+    def dispatch(self, *args, **kwargs):
+        return super(CompetitionOrganizerTeams, self).dispatch(*args, **kwargs)
+
+    def get_form(self, form_class=None):
+        if self.kwargs.get('pk'):
+            current_team = Team.objects.get(pk=self.kwargs['pk'])
+            return form_class(instance=current_team, **self.get_form_kwargs())
+        else:
+            return form_class(**self.get_form_kwargs())
+
+    def get_form_kwargs(self):
+        kwargs = super(CompetitionOrganizerTeams, self).get_form_kwargs()
+        competition = Competition.objects.get(pk=self.kwargs['competition_pk'])
+        kwargs['competition_pk'] = self.kwargs['competition_pk']
+        kwargs['creator_pk'] = competition.creator.pk
+        return kwargs
+
+    def form_valid(self, form):
+        try:
+            competition = Competition.objects.get(pk=self.kwargs['competition_pk'])
+        except ObjectDoesNotExist:
+            print("Could not find a competition for that PK!")
+        form.save()
+        self.success_url = reverse("my_competition_participants", kwargs={'competition_id': competition.pk})
+        return super(CompetitionOrganizerTeams, self).form_valid(form)
+
+    def get_context_data(self, **kwargs):
+        context = super(CompetitionOrganizerTeams, self).get_context_data(**kwargs)
+        try:
+            competition = Competition.objects.get(pk=self.kwargs['competition_pk'])
+            context['competition'] = competition
+        except ObjectDoesNotExist:
+            print("Could not find a competition for that PK!")
+        return context
+
+
+@login_required
+def delete_organizer_team(request, team_pk, competition_pk):
+    try:
+        comp = Competition.objects.get(pk=competition_pk)
+        team_to_delete = Team.objects.get(pk=team_pk)
+        if request.user != team_to_delete.creator or request.user != team_to_delete.competition.creator:
+            if request.user not in comp.admins.all():
+                return HttpResponseForbidden(status=403)
+        else:
+            # comp_pk = team_to_delete.competition.pk
+            print("Deleting team {0} from competition {1}".format(team_to_delete, comp))
+            team_to_delete.delete()
+            return redirect('my_competition_participants', competition_id=comp.pk)
+    except ObjectDoesNotExist:
+        return HttpResponse(status=404)
+
+
+class CompetitionOrganizerCSVTeams(FormView):
+    form_class = OrganizerTeamsCSVForm
+    template_name = 'teams/competitions/organizer_csv_teams.html'
+
+    @method_decorator(login_required)
+    def dispatch(self, *args, **kwargs):
+        return super(CompetitionOrganizerCSVTeams, self).dispatch(*args, **kwargs)
+
+    # success_url = reverse('competitions:participants')
+    def get_form_kwargs(self):
+        kwargs = super(CompetitionOrganizerCSVTeams, self).get_form_kwargs()
+        competition = Competition.objects.get(pk=self.kwargs['competition_pk'])
+        kwargs['competition_pk'] = self.kwargs['competition_pk']
+        kwargs['creator_pk'] = competition.creator.pk
+        return kwargs
+
+    def form_valid(self, form):
+        try:
+            competition = Competition.objects.get(pk=self.kwargs['competition_pk'])
+        except ObjectDoesNotExist:
+            print("Could not find a competition for that PK!")
+        form.save()
+        self.success_url = reverse("my_competition_participants", kwargs={'competition_id': competition.pk})
+        return super(CompetitionOrganizerCSVTeams, self).form_valid(form)
+
+    def get_context_data(self, **kwargs):
+        context = super(CompetitionOrganizerCSVTeams, self).get_context_data(**kwargs)
+        context['competition'] = Competition.objects.get(pk=self.kwargs['competition_pk'])
         return context

--- a/codalab/apps/teams/views.py
+++ b/codalab/apps/teams/views.py
@@ -424,4 +424,6 @@ class CompetitionOrganizerCSVTeams(FormView):
 
     def get_context_data(self, **kwargs):
         context = super(CompetitionOrganizerCSVTeams, self).get_context_data(**kwargs)
+        competition = Competition.objects.get(pk=self.kwargs['competition_pk'])
+        context['competition'] = competition
         return context

--- a/codalab/apps/web/forms.py
+++ b/codalab/apps/web/forms.py
@@ -46,6 +46,7 @@ class CompetitionForm(forms.ModelForm):
             'enable_forum',
             'anonymous_leaderboard',
             'enable_teams',
+            'allow_organizer_teams',
             'require_team_approval',
             'competition_docker_image',
             'hide_top_three',
@@ -292,3 +293,8 @@ class SubmissionS3UploadForm(forms.ModelForm):
 
         self.fields['s3_file'].required = True
         self.fields['s3_file'].label = ''
+
+
+class OrganizerTeamForm(forms.Form):
+    team_name = forms.CharField()
+    team_members = forms.CharField(widget=forms.Textarea)

--- a/codalab/apps/web/forms.py
+++ b/codalab/apps/web/forms.py
@@ -293,8 +293,3 @@ class SubmissionS3UploadForm(forms.ModelForm):
 
         self.fields['s3_file'].required = True
         self.fields['s3_file'].label = ''
-
-
-class OrganizerTeamForm(forms.Form):
-    team_name = forms.CharField()
-    team_members = forms.CharField(widget=forms.Textarea)

--- a/codalab/apps/web/migrations/0080_auto__add_field_competition_allow_organizer_teams.py
+++ b/codalab/apps/web/migrations/0080_auto__add_field_competition_allow_organizer_teams.py
@@ -1,0 +1,492 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'Competition.allow_organizer_teams'
+        db.add_column(u'web_competition', 'allow_organizer_teams',
+                      self.gf('django.db.models.fields.BooleanField')(default=False),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'Competition.allow_organizer_teams'
+        db.delete_column(u'web_competition', 'allow_organizer_teams')
+
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'authenz.cluser': {
+            'Meta': {'object_name': 'ClUser'},
+            'bibtex': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'contact_email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'null': 'True', 'blank': 'True'}),
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'email_on_submission_finished_successfully': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'method_description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'method_name': ('django.db.models.fields.CharField', [], {'max_length': '20', 'null': 'True', 'blank': 'True'}),
+            'organization_or_affiliation': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'organizer_direct_message_updates': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'organizer_status_updates': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'participation_status_updates': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'project_url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'publication_url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'rabbitmq_password': ('django.db.models.fields.CharField', [], {'max_length': '36', 'null': 'True', 'blank': 'True'}),
+            'rabbitmq_queue_limit': ('django.db.models.fields.PositiveIntegerField', [], {'default': '5', 'blank': 'True'}),
+            'rabbitmq_username': ('django.db.models.fields.CharField', [], {'max_length': '36', 'null': 'True', 'blank': 'True'}),
+            'team_members': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'team_name': ('django.db.models.fields.CharField', [], {'max_length': '64', 'null': 'True', 'blank': 'True'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'queues.queue': {
+            'Meta': {'object_name': 'Queue'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_public': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '64'}),
+            'organizers': ('django.db.models.fields.related.ManyToManyField', [], {'blank': 'True', 'related_name': "'organizers'", 'null': 'True', 'symmetrical': 'False', 'to': u"orm['authenz.ClUser']"}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['authenz.ClUser']"}),
+            'vhost': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '36', 'blank': 'True'})
+        },
+        u'teams.team': {
+            'Meta': {'unique_together': "(('name', 'competition'),)", 'object_name': 'Team'},
+            'allow_requests': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'competition': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['web.Competition']"}),
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'null': 'True', 'blank': 'True'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'team_creator'", 'to': u"orm['authenz.ClUser']"}),
+            'description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'image': ('django.db.models.fields.files.FileField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'image_url_base': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'last_modified': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'members': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['authenz.ClUser']", 'null': 'True', 'through': u"orm['teams.TeamMembership']", 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'reason': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'status': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['teams.TeamStatus']", 'null': 'True'})
+        },
+        u'teams.teammembership': {
+            'Meta': {'object_name': 'TeamMembership'},
+            'end_date': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_invitation': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_request': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'message': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'reason': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'start_date': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'status': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['teams.TeamMembershipStatus']", 'null': 'True'}),
+            'team': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['teams.Team']"}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['authenz.ClUser']"})
+        },
+        u'teams.teammembershipstatus': {
+            'Meta': {'object_name': 'TeamMembershipStatus'},
+            'codename': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'}),
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '30'})
+        },
+        u'teams.teamstatus': {
+            'Meta': {'object_name': 'TeamStatus'},
+            'codename': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'}),
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '30'})
+        },
+        u'web.competition': {
+            'Meta': {'ordering': "['end_date']", 'object_name': 'Competition'},
+            'admins': ('django.db.models.fields.related.ManyToManyField', [], {'blank': 'True', 'related_name': "'competition_admins'", 'null': 'True', 'symmetrical': 'False', 'to': u"orm['authenz.ClUser']"}),
+            'allow_organizer_teams': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'allow_public_submissions': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'allow_teams': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'anonymous_leaderboard': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'chahub_data_hash': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'chahub_needs_retry': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'chahub_timestamp': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'competition_docker_image': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '128', 'blank': 'True'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'competitioninfo_creator'", 'to': u"orm['authenz.ClUser']"}),
+            'description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'disallow_leaderboard_modifying': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'enable_detailed_results': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'enable_forum': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'enable_medical_image_viewer': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'enable_per_submission_metadata': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'enable_teams': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'end_date': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'force_submission_to_leaderboard': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'has_registration': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'hide_chart': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'hide_top_three': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'image': ('django.db.models.fields.files.FileField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'image_url_base': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'is_migrating': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_migrating_delayed': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_modified': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'last_phase_migration': ('django.db.models.fields.PositiveIntegerField', [], {'default': '1'}),
+            'modified_by': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'competitioninfo_modified_by'", 'to': u"orm['authenz.ClUser']"}),
+            'original_yaml_file': ('django.db.models.fields.TextField', [], {'default': "''", 'null': 'True', 'blank': 'True'}),
+            'published': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'queue': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'competitions'", 'null': 'True', 'on_delete': 'models.SET_NULL', 'to': u"orm['queues.Queue']"}),
+            'require_team_approval': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'reward': ('django.db.models.fields.PositiveIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'secret_key': ('django.db.models.fields.CharField', [], {'max_length': '36', 'blank': 'True'}),
+            'show_datasets_from_yaml': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'start_date': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'teams': ('django.db.models.fields.related.ManyToManyField', [], {'blank': 'True', 'related_name': "'competition_teams'", 'null': 'True', 'symmetrical': 'False', 'to': u"orm['teams.Team']"}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'web.competitiondefbundle': {
+            'Meta': {'object_name': 'CompetitionDefBundle'},
+            'config_bundle': ('django.db.models.fields.files.FileField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'owner'", 'to': u"orm['authenz.ClUser']"}),
+            's3_config_bundle': ('s3direct.fields.S3DirectField', [], {'null': 'True', 'blank': 'True'})
+        },
+        u'web.competitiondump': {
+            'Meta': {'object_name': 'CompetitionDump'},
+            'competition': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'dumps'", 'to': u"orm['web.Competition']"}),
+            'data_file': ('django.db.models.fields.files.FileField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'status': ('django.db.models.fields.CharField', [], {'default': "'Starting'", 'max_length': '64'}),
+            'timestamp': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'})
+        },
+        u'web.competitionparticipant': {
+            'Meta': {'unique_together': "(('user', 'competition'),)", 'object_name': 'CompetitionParticipant'},
+            'competition': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'participants'", 'to': u"orm['web.Competition']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'reason': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'status': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['web.ParticipantStatus']"}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'participation'", 'to': u"orm['authenz.ClUser']"})
+        },
+        u'web.competitionphase': {
+            'Meta': {'ordering': "['phasenumber']", 'object_name': 'CompetitionPhase'},
+            'auto_migration': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'color': ('django.db.models.fields.CharField', [], {'max_length': '24', 'null': 'True', 'blank': 'True'}),
+            'competition': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'phases'", 'to': u"orm['web.Competition']"}),
+            'datasets': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "'phase'", 'blank': 'True', 'to': u"orm['web.Dataset']"}),
+            'default_docker_image': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '128', 'blank': 'True'}),
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '1000', 'null': 'True', 'blank': 'True'}),
+            'disable_custom_docker_image': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'execution_time_limit': ('django.db.models.fields.PositiveIntegerField', [], {'default': '300'}),
+            'force_best_submission_to_leaderboard': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'ingestion_program': ('django.db.models.fields.files.FileField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'ingestion_program_docker_image': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '128', 'blank': 'True'}),
+            'ingestion_program_organizer_dataset': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'ingestion_program_organizer_dataset'", 'null': 'True', 'on_delete': 'models.SET_NULL', 'to': u"orm['web.OrganizerDataSet']"}),
+            'input_data': ('django.db.models.fields.files.FileField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'input_data_organizer_dataset': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'input_data_organizer_dataset'", 'null': 'True', 'on_delete': 'models.SET_NULL', 'to': u"orm['web.OrganizerDataSet']"}),
+            'is_migrated': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_scoring_only': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'label': ('django.db.models.fields.CharField', [], {'max_length': '50', 'blank': 'True'}),
+            'leaderboard_management_mode': ('django.db.models.fields.CharField', [], {'default': "'default'", 'max_length': '50'}),
+            'max_submissions': ('django.db.models.fields.PositiveIntegerField', [], {'default': '100'}),
+            'max_submissions_per_day': ('django.db.models.fields.PositiveIntegerField', [], {'default': '999'}),
+            'phase_never_ends': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'phasenumber': ('django.db.models.fields.PositiveIntegerField', [], {}),
+            'public_data': ('django.db.models.fields.files.FileField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'public_data_organizer_dataset': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'public_data_organizer_dataset'", 'null': 'True', 'on_delete': 'models.SET_NULL', 'to': u"orm['web.OrganizerDataSet']"}),
+            'reference_data': ('django.db.models.fields.files.FileField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'reference_data_organizer_dataset': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'reference_data_organizer_dataset'", 'null': 'True', 'on_delete': 'models.SET_NULL', 'to': u"orm['web.OrganizerDataSet']"}),
+            'scoring_program': ('django.db.models.fields.files.FileField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'scoring_program_docker_image': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '128', 'blank': 'True'}),
+            'scoring_program_organizer_dataset': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'scoring_program_organizer_dataset'", 'null': 'True', 'on_delete': 'models.SET_NULL', 'to': u"orm['web.OrganizerDataSet']"}),
+            'start_date': ('django.db.models.fields.DateTimeField', [], {}),
+            'starting_kit': ('django.db.models.fields.files.FileField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'starting_kit_organizer_dataset': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'starting_kit_organizer_dataset'", 'null': 'True', 'on_delete': 'models.SET_NULL', 'to': u"orm['web.OrganizerDataSet']"})
+        },
+        u'web.competitionsubmission': {
+            'Meta': {'unique_together': "(('submission_number', 'phase', 'participant'),)", 'object_name': 'CompetitionSubmission'},
+            'bibtex': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'chahub_data_hash': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'chahub_needs_retry': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'chahub_timestamp': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'completed_at': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'coopetition_file': ('django.db.models.fields.files.FileField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '256', 'blank': 'True'}),
+            'detailed_results_file': ('django.db.models.fields.files.FileField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'dislike_count': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'docker_image': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '128', 'blank': 'True'}),
+            'download_count': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'exception_details': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'execution_key': ('django.db.models.fields.TextField', [], {'default': "''", 'blank': 'True'}),
+            'file': ('django.db.models.fields.files.FileField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'file_url_base': ('django.db.models.fields.CharField', [], {'max_length': '2000', 'blank': 'True'}),
+            'history_file': ('django.db.models.fields.files.FileField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'ingestion_program_stderr_file': ('django.db.models.fields.files.FileField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'ingestion_program_stdout_file': ('django.db.models.fields.files.FileField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'inputfile': ('django.db.models.fields.files.FileField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'is_migrated': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_public': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'like_count': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'method_description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'method_name': ('django.db.models.fields.CharField', [], {'max_length': '20', 'null': 'True', 'blank': 'True'}),
+            'organization_or_affiliation': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'output_file': ('django.db.models.fields.files.FileField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'participant': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'submissions'", 'to': u"orm['web.CompetitionParticipant']"}),
+            'phase': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'submissions'", 'to': u"orm['web.CompetitionPhase']"}),
+            'prediction_output_file': ('django.db.models.fields.files.FileField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'prediction_runfile': ('django.db.models.fields.files.FileField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'prediction_stderr_file': ('django.db.models.fields.files.FileField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'prediction_stdout_file': ('django.db.models.fields.files.FileField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'private_output_file': ('django.db.models.fields.files.FileField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'project_url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'publication_url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'queue_name': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'readable_filename': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'runfile': ('django.db.models.fields.files.FileField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            's3_file': ('s3direct.fields.S3DirectField', [], {'null': 'True', 'blank': 'True'}),
+            'scores_file': ('django.db.models.fields.files.FileField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'secret': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '128', 'blank': 'True'}),
+            'started_at': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'status': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['web.CompetitionSubmissionStatus']"}),
+            'status_details': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'stderr_file': ('django.db.models.fields.files.FileField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'stdout_file': ('django.db.models.fields.files.FileField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'submission_number': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'submitted_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'team': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'team'", 'null': 'True', 'to': u"orm['teams.Team']"}),
+            'team_name': ('django.db.models.fields.CharField', [], {'max_length': '64', 'null': 'True', 'blank': 'True'}),
+            'when_made_public': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'when_unmade_public': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'})
+        },
+        u'web.competitionsubmissionmetadata': {
+            'Meta': {'object_name': 'CompetitionSubmissionMetadata'},
+            'beginning_cpu_usage': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'beginning_swap_memory_usage': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'beginning_virtual_memory_usage': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'end_cpu_usage': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'end_swap_memory_usage': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'end_virtual_memory_usage': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'hostname': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'ingestion_program_duration': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'is_predict': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_scoring': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'processes_running_in_temp_dir': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'submission': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'metadatas'", 'to': u"orm['web.CompetitionSubmission']"})
+        },
+        u'web.competitionsubmissionstatus': {
+            'Meta': {'object_name': 'CompetitionSubmissionStatus'},
+            'codename': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '20'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '20'})
+        },
+        u'web.contentcategory': {
+            'Meta': {'object_name': 'ContentCategory'},
+            'codename': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '100'}),
+            'content_limit': ('django.db.models.fields.PositiveIntegerField', [], {'default': '1'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_menu': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'level': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'lft': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'parent': ('mptt.fields.TreeForeignKey', [], {'blank': 'True', 'related_name': "'children'", 'null': 'True', 'to': u"orm['web.ContentCategory']"}),
+            'rght': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'tree_id': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'visibility': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['web.ContentVisibility']"})
+        },
+        u'web.contentvisibility': {
+            'Meta': {'object_name': 'ContentVisibility'},
+            'classname': ('django.db.models.fields.CharField', [], {'max_length': '30', 'null': 'True', 'blank': 'True'}),
+            'codename': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '20'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '20'})
+        },
+        u'web.dataset': {
+            'Meta': {'ordering': "['number']", 'object_name': 'Dataset'},
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'datasets'", 'to': u"orm['authenz.ClUser']"}),
+            'datafile': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['web.ExternalFile']"}),
+            'description': ('django.db.models.fields.TextField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'number': ('django.db.models.fields.PositiveIntegerField', [], {'default': '1'})
+        },
+        u'web.defaultcontentitem': {
+            'Meta': {'object_name': 'DefaultContentItem'},
+            'category': ('mptt.fields.TreeForeignKey', [], {'to': u"orm['web.ContentCategory']"}),
+            'codename': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'initial_visibility': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['web.ContentVisibility']"}),
+            'label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'rank': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'required': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        },
+        u'web.externalfile': {
+            'Meta': {'object_name': 'ExternalFile'},
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['authenz.ClUser']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'source_address_info': ('django.db.models.fields.CharField', [], {'max_length': '200', 'blank': 'True'}),
+            'source_url': ('django.db.models.fields.URLField', [], {'max_length': '200'}),
+            'type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['web.ExternalFileType']"})
+        },
+        u'web.externalfilesource': {
+            'Meta': {'object_name': 'ExternalFileSource'},
+            'codename': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '50'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'service_url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'})
+        },
+        u'web.externalfiletype': {
+            'Meta': {'object_name': 'ExternalFileType'},
+            'codename': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '20'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '20'})
+        },
+        u'web.organizerdataset': {
+            'Meta': {'object_name': 'OrganizerDataSet'},
+            'data_file': ('django.db.models.fields.files.FileField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'full_name': ('django.db.models.fields.TextField', [], {'default': "''"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'max_length': '36', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'sub_data_files': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['web.OrganizerDataSet']", 'null': 'True', 'blank': 'True'}),
+            'type': ('django.db.models.fields.CharField', [], {'default': "'None'", 'max_length': '64'}),
+            'uploaded_by': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['authenz.ClUser']"})
+        },
+        u'web.page': {
+            'Meta': {'ordering': "['category', 'rank']", 'unique_together': "(('label', 'category', 'container'),)", 'object_name': 'Page'},
+            'category': ('mptt.fields.TreeForeignKey', [], {'to': u"orm['web.ContentCategory']"}),
+            'codename': ('django.db.models.fields.SlugField', [], {'max_length': '100'}),
+            'competition': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'pages'", 'null': 'True', 'to': u"orm['web.Competition']"}),
+            'container': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'pages'", 'to': u"orm['web.PageContainer']"}),
+            'defaults': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['web.DefaultContentItem']", 'null': 'True', 'blank': 'True'}),
+            'html': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'markup': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'rank': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'visibility': ('django.db.models.fields.BooleanField', [], {'default': 'True'})
+        },
+        u'web.pagecontainer': {
+            'Meta': {'unique_together': "(('object_id', 'content_type'),)", 'object_name': 'PageContainer'},
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200', 'blank': 'True'}),
+            'object_id': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'})
+        },
+        u'web.participantstatus': {
+            'Meta': {'object_name': 'ParticipantStatus'},
+            'codename': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'}),
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '30'})
+        },
+        u'web.phaseleaderboard': {
+            'Meta': {'object_name': 'PhaseLeaderBoard'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'phase': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'board'", 'unique': 'True', 'to': u"orm['web.CompetitionPhase']"})
+        },
+        u'web.phaseleaderboardentry': {
+            'Meta': {'unique_together': "(('board', 'result'),)", 'object_name': 'PhaseLeaderBoardEntry'},
+            'board': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'entries'", 'to': u"orm['web.PhaseLeaderBoard']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'result': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'leaderboard_entry_result'", 'to': u"orm['web.CompetitionSubmission']"})
+        },
+        u'web.submissioncomputedscore': {
+            'Meta': {'object_name': 'SubmissionComputedScore'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'operation': ('django.db.models.fields.CharField', [], {'max_length': '10'}),
+            'scoredef': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'computed_score'", 'unique': 'True', 'to': u"orm['web.SubmissionScoreDef']"})
+        },
+        u'web.submissioncomputedscorefield': {
+            'Meta': {'object_name': 'SubmissionComputedScoreField'},
+            'computed': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'fields'", 'to': u"orm['web.SubmissionComputedScore']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'scoredef': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['web.SubmissionScoreDef']"})
+        },
+        u'web.submissionresultgroup': {
+            'Meta': {'ordering': "['ordering']", 'object_name': 'SubmissionResultGroup'},
+            'competition': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['web.Competition']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'label': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'ordering': ('django.db.models.fields.PositiveIntegerField', [], {'default': '1'}),
+            'phases': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['web.CompetitionPhase']", 'through': u"orm['web.SubmissionResultGroupPhase']", 'symmetrical': 'False'})
+        },
+        u'web.submissionresultgroupphase': {
+            'Meta': {'unique_together': "(('group', 'phase'),)", 'object_name': 'SubmissionResultGroupPhase'},
+            'group': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['web.SubmissionResultGroup']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'phase': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['web.CompetitionPhase']"})
+        },
+        u'web.submissionscore': {
+            'Meta': {'unique_together': "(('result', 'scoredef'),)", 'object_name': 'SubmissionScore'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'result': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'scores'", 'to': u"orm['web.CompetitionSubmission']"}),
+            'scoredef': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['web.SubmissionScoreDef']"}),
+            'value': ('django.db.models.fields.DecimalField', [], {'max_digits': '20', 'decimal_places': '10'})
+        },
+        u'web.submissionscoredef': {
+            'Meta': {'unique_together': "(('key', 'competition'),)", 'object_name': 'SubmissionScoreDef'},
+            'competition': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['web.Competition']"}),
+            'computed': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['web.SubmissionResultGroup']", 'through': u"orm['web.SubmissionScoreDefGroup']", 'symmetrical': 'False'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.SlugField', [], {'max_length': '50'}),
+            'label': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'numeric_format': ('django.db.models.fields.CharField', [], {'max_length': '20', 'null': 'True', 'blank': 'True'}),
+            'ordering': ('django.db.models.fields.PositiveIntegerField', [], {'default': '1'}),
+            'selection_default': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'show_rank': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'sorting': ('django.db.models.fields.SlugField', [], {'default': "'asc'", 'max_length': '20'})
+        },
+        u'web.submissionscoredefgroup': {
+            'Meta': {'unique_together': "(('scoredef', 'group'),)", 'object_name': 'SubmissionScoreDefGroup'},
+            'group': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['web.SubmissionResultGroup']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'scoredef': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['web.SubmissionScoreDef']"})
+        },
+        u'web.submissionscoreset': {
+            'Meta': {'unique_together': "(('key', 'competition'),)", 'object_name': 'SubmissionScoreSet'},
+            'competition': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['web.Competition']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'label': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'level': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'lft': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'ordering': ('django.db.models.fields.PositiveIntegerField', [], {'default': '1'}),
+            'parent': ('mptt.fields.TreeForeignKey', [], {'blank': 'True', 'related_name': "'children'", 'null': 'True', 'to': u"orm['web.SubmissionScoreSet']"}),
+            'rght': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'scoredef': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['web.SubmissionScoreDef']", 'null': 'True', 'blank': 'True'}),
+            'tree_id': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'})
+        }
+    }
+
+    complete_apps = ['web']

--- a/codalab/apps/web/models.py
+++ b/codalab/apps/web/models.py
@@ -1329,6 +1329,7 @@ class CompetitionSubmission(ChaHubSaveMixin, models.Model):
     is_migrated = models.BooleanField(default=False) # Will be used to auto  migrate
 
     # Team of the user in the moment of the submission
+    # This field is not used anywhere we can see 4/18/2018
     team = models.ForeignKey(Team, related_name='team', null=True, blank=True)
 
     queue_name = models.TextField(null=True, blank=True)

--- a/codalab/apps/web/models.py
+++ b/codalab/apps/web/models.py
@@ -264,6 +264,7 @@ class Competition(ChaHubSaveMixin, models.Model):
     teams = models.ManyToManyField(Team, related_name='competition_teams', blank=True, null=True)
     hide_top_three = models.BooleanField(default=False, verbose_name="Hide Top Three Leaderboard")
     hide_chart = models.BooleanField(default=False, verbose_name="Hide Chart")
+    allow_organizer_teams = models.BooleanField(default=False, verbose_name="Allow Organizer Teams")
 
     competition_docker_image = models.CharField(max_length=128, default='', blank=True)
 

--- a/codalab/apps/web/templates/web/competitions/view.html
+++ b/codalab/apps/web/templates/web/competitions/view.html
@@ -138,7 +138,7 @@
                     {% if competition.enable_forum %}
                     <li><a href="{% url 'forum_detail' forum_pk=competition.forum.pk %}">Forums <i class="glyphicon glyphicon-log-in"></i></a></li>
                     {% endif %}
-                    {% if competition.enable_teams %}
+                    {% if competition.enable_teams and not competition.allow_organizer_teams %}
                         {% if my_status == "approved" %}
                             <li>
                                 <a href="{% url 'team_detail' competition_pk=competition.pk %}">Team

--- a/codalab/apps/web/templates/web/my/organizer_teams.html
+++ b/codalab/apps/web/templates/web/my/organizer_teams.html
@@ -1,0 +1,23 @@
+{% extends 'base.html' %}
+{% load staticfiles %}
+{% load codalab_tags %}
+{% load tz %}
+
+{% block page_title %}Participants{% endblock page_title %}
+{% block head_title %}Participants{% endblock %}
+
+{% block extra_head %}
+    <script src="{% static 'js/foundation/vendor/jquery.validate.min.js' %}"></script>
+{% endblock %}
+
+{% block content %}
+
+<a href="{% url "competitions:view" pk=competition.pk %}" class="pull-right" >Go Back to Competition Homepage</a>
+
+    <form action="" method="post">
+        {% csrf_token %}
+        {{ my_form.as_p }}
+        <input type="submit" value="Submit">
+    </form>
+
+{% endblock %}

--- a/codalab/apps/web/templates/web/my/participants.html
+++ b/codalab/apps/web/templates/web/my/participants.html
@@ -13,11 +13,19 @@
 {% block content %}
 
 <a href="{% url "competitions:view" pk=competition_id %}" class="pull-right" >Go Back to Competition Homepage</a>
-<a href="{% url "competitions:create_org_team" competition_pk=competition_id %}" class="pull-middle btn btn-default" >Create Organizer Team</a>
+{% if allow_organizer_teams %}
+    <a href="{% url "create_org_team" competition_pk=competition_id %}" class="pull-middle btn btn-default" >Create Organizer Team</a>
+    {{ csv_form.non_field_errors }}
+    <form action="{% url "create_org_teams_from_csv" competition_pk=competition_id %}" method="POST" enctype="multipart/form-data">
+        {% csrf_token %}
+        {{ csv_form.as_p }}
+        <input type="submit" value="Submit">
+    </form>
+{% endif %}
 
 <div class="participants">
     <h3>Teams</h3>
-    {% if teams_enabled %}
+    {% if teams_enabled or allow_organizer_teams %}
         {% if not allow_organizer_teams %}
             {% if pending_teams %}
                 {% for item in pending_teams %}
@@ -43,7 +51,7 @@
                             {% if item.status.codename == 'denied' %}
                                 <p class="text-danger">Reason: {{ item.reason }}</p>
                             {% endif %}
-                            <form class="custom process_request" id="team_request_{{ item.id }}">{% csrf_token %}
+                            <form class="custom process_request form-participate" id="team_request_{{ item.id }}">{% csrf_token %}
                                 <input type="hidden" name="team_id" value="{{ item.id }}"/>
                                 <div class="row">
                                     <div class="col-sm-4">
@@ -102,6 +110,9 @@
                                             class="pull-right btn btn-success btn-sm team_reinstate_button button {% if team.status == "approved" %}hide{% endif %}"
                                             team_id="{{ team.pk }}">Reinstate
                                     </button>
+                                {% else %}
+                                    <a href="{% url "edit_org_team" competition_pk=competition_id pk=team.pk %}" class="pull-right button btn-primary btn-xs">Edit</a>
+                                    <a href="{% url "delete_org_team" competition_pk=competition_id team_pk=team.pk %}" class="pull-right button btn-danger btn-xs">Delete</a>
                                 {% endif %}
                             {% else %}
                                 {{ team|get_item:column.name }}
@@ -144,7 +155,7 @@
                             {% if item.status.codename == 'denied' %}
                                 <p class="text-danger">Reason: {{ item.reason }}</p>
                             {% endif %}
-                            <form class="custom process_request" id="process_request_{{ item.id }}">{% csrf_token %}
+                            <form class="custom process_request form-participate" id="process_request_{{ item.id }}">{% csrf_token %}
                                 <input type="hidden" name="participant_id" value="{{ item.id }}"/>
                                 <div class="row">
                                     <div class="col-sm-4">
@@ -228,7 +239,7 @@
                 <h4 class="modal-title">Email Participants</h4>
             </div>
             <div class="modal-body">
-                <form id="message-form">
+                <form class="form-participate" id="message-form">
                     <div class="form-group">
                         <input id="subject_input" type="text" placeholder="Subject" class="form-control">
                             <div class="alert alert-danger" id="subject-alert" role="alert">
@@ -318,7 +329,7 @@
                                     'approved': '' };
 
     /* attach a submit handler to the form */
-    $("form").submit(function(event) {
+    $(".form-participate").submit(function(event) {
 
         /* stop form from submitting normally */
         event.preventDefault();

--- a/codalab/apps/web/templates/web/my/participants.html
+++ b/codalab/apps/web/templates/web/my/participants.html
@@ -13,58 +13,61 @@
 {% block content %}
 
 <a href="{% url "competitions:view" pk=competition_id %}" class="pull-right" >Go Back to Competition Homepage</a>
+<a href="{% url "competitions:create_org_team" competition_pk=competition_id %}" class="pull-middle btn btn-default" >Create Organizer Team</a>
 
 <div class="participants">
     <h3>Teams</h3>
     {% if teams_enabled %}
-        {% if pending_teams %}
-            {% for item in pending_teams %}
-                <div class="panel panel-default competitionUserBlock teamUserBlock_{{item.id}}">
-                    <div class="panel-heading">
-                        <h3 class="panel-title">{{ item.name }}
-                            <span class="participationStatus label label-{{ item.status.codename }}">
-                                {% if item.status.codename == 'pending' %}
-                                    Team pending approval
-                                {% elif item.status.codename == 'approved' %}
-                                    Team approved
-                                {% elif item.status.codename == 'denied' %}
-                                    Team denied
-                                {% elif item.status.codename == 'deleted' %}
-                                    Team deleted
-                                {% else %}
-                                    Unknown Status
-                                {% endif %}
-                            </span>
-                        </h3>
-                    </div>
-                    <div class="panel-body">
-                        {% if item.status.codename == 'denied' %}
-                            <p class="text-danger">Reason: {{ item.reason }}</p>
-                        {% endif %}
-                        <form class="custom process_request" id="team_request_{{item.id}}">{% csrf_token %}
-                            <input type="hidden" name="team_id" value="{{item.id}}"/>
-                            <div class="row">
-                                <div class="col-sm-4">
-                                    <div class="form-group">
-                                        <label for="status">Status:</label>
-                                        <select id="status" name="status" class="form-control">
-                                            <option value="approved">Approve</option>
-                                            <option value="denied">Deny</option>
-                                        </select>
+        {% if not allow_organizer_teams %}
+            {% if pending_teams %}
+                {% for item in pending_teams %}
+                    <div class="panel panel-default competitionUserBlock teamUserBlock_{{ item.id }}">
+                        <div class="panel-heading">
+                            <h3 class="panel-title">{{ item.name }}
+                                <span class="participationStatus label label-{{ item.status.codename }}">
+                                    {% if item.status.codename == 'pending' %}
+                                        Team pending approval
+                                    {% elif item.status.codename == 'approved' %}
+                                        Team approved
+                                    {% elif item.status.codename == 'denied' %}
+                                        Team denied
+                                    {% elif item.status.codename == 'deleted' %}
+                                        Team deleted
+                                    {% else %}
+                                        Unknown Status
+                                    {% endif %}
+                                </span>
+                            </h3>
+                        </div>
+                        <div class="panel-body">
+                            {% if item.status.codename == 'denied' %}
+                                <p class="text-danger">Reason: {{ item.reason }}</p>
+                            {% endif %}
+                            <form class="custom process_request" id="team_request_{{ item.id }}">{% csrf_token %}
+                                <input type="hidden" name="team_id" value="{{ item.id }}"/>
+                                <div class="row">
+                                    <div class="col-sm-4">
+                                        <div class="form-group">
+                                            <label for="status">Status:</label>
+                                            <select id="status" name="status" class="form-control">
+                                                <option value="approved">Approve</option>
+                                                <option value="denied">Deny</option>
+                                            </select>
+                                        </div>
+                                    </div>
+                                    <div class="col-sm-8">
+                                        <div class="form-group">
+                                            <label for="reason">Reason:</label>
+                                            <textarea id="reason" name="reason" class="form-control"></textarea>
+                                        </div>
                                     </div>
                                 </div>
-                                <div class="col-sm-8">
-                                    <div class="form-group">
-                                        <label for="reason">Reason:</label>
-                                        <textarea id="reason" name="reason" class="form-control"></textarea>
-                                    </div>
-                                </div>
-                            </div>
-                            <input type="submit" class="btn btn-primary pull-right" value="Process" />
-                        </form>
+                                <input type="submit" class="btn btn-primary pull-right" value="Process"/>
+                            </form>
+                        </div>
                     </div>
-                </div>
-            {% endfor %}
+                {% endfor %}
+            {% endif %}
         {% endif %}
         {% if not team_list %}
              <p><em>There are no teams.</em></p>
@@ -90,8 +93,16 @@
                                 <span class="label label-{{team|get_item:column.name}}">
                                     {{team|get_item:column.name}}
                                 </span>
-                                <button type="button" class="pull-right btn btn-danger btn-sm team_revoke_button button {% if team.status == "denied" %}hide{% endif %}" team_id="{{ team.pk }}">Revoke</button>
-                                <button type="button" class="pull-right btn btn-success btn-sm team_reinstate_button button {% if team.status == "approved" %}hide{% endif %}" team_id="{{ team.pk }}">Reinstate</button>
+                                {% if not allow_organizer_teams %}
+                                    <button type="button"
+                                            class="pull-right btn btn-danger btn-sm team_revoke_button button {% if team.status == "denied" %}hide{% endif %}"
+                                            team_id="{{ team.pk }}">Revoke
+                                    </button>
+                                    <button type="button"
+                                            class="pull-right btn btn-success btn-sm team_reinstate_button button {% if team.status == "approved" %}hide{% endif %}"
+                                            team_id="{{ team.pk }}">Reinstate
+                                    </button>
+                                {% endif %}
                             {% else %}
                                 {{ team|get_item:column.name }}
                             {% endif %}
@@ -106,90 +117,107 @@
 </div>
 <div class="participants">
     <h3>Participants</h3>
-    {% if not object_list %}
-        <p><em>There are no participants.</em></p>
-    {% else %}
-        {% for item in pending_participants %}
-            <div class="panel panel-default competitionUserBlock competitionUserBlock_{{item.id}}">
-                <div class="panel-heading">
-                    <h3 class="panel-title">{{ item.user.username }}
-                        <span class="participationStatus label label-{{ item.status.codename }}">
-                            {% if item.status.codename == 'pending' %}
-                                Participation pending approval
-                            {% elif item.status.codename == 'approved' %}
-                                Participation approved
-                            {% elif item.status.codename == 'denied' %}
-                                Participation denied
-                            {% else %}
-                                Unknown Status
-                            {% endif %}
-                        </span>
-                    </h3>
-                </div>
-                <div class="panel-body">
-                    {% if item.status.codename == 'denied' %}
-                        <p class="text-danger">Reason: {{ item.reason }}</p>
-                    {% endif %}
-                    <form class="custom process_request" id="process_request_{{item.id}}">{% csrf_token %}
-                        <input type="hidden" name="participant_id" value="{{item.id}}"/>
-                        <div class="row">
-                            <div class="col-sm-4">
-                                <div class="form-group">
-                                    <label for="status">Status:</label>
-                                    <select id="status" name="status" class="form-control">
-                                        <option value="approved">Approve</option>
-                                        <option value="denied">Deny</option>
-                                    </select>
-                                </div>
-                            </div>
-                            <div class="col-sm-8">
-                                <div class="form-group">
-                                    <label for="reason">Reason:</label>
-                                    <textarea id="reason" name="reason" class="form-control"></textarea>
-                                </div>
-                            </div>
-                        </div>
-                        <input type="submit" class="btn btn-primary pull-right" value="Process" />
-                    </form>
-                </div>
-            </div>
-        {% endfor %}
 
-        <button type="button" data-toggle="modal" href="#message_all_modal" class="btn btn-primary">Send message to all participants?</button>
-
-        <table class="resultsTable dataTable table table-striped table-bordered">
-            <thead>
-                <tr>
-                    {% for column in columns %}
-                    <th>
-                        <a href="?order={{column.name}}{% if direction == 'asc' and order == column.name %}&direction=desc{% endif %}">
-                            {{column.label}} <i class="{% if order == column.name %}{% if direction == 'asc'%}fi-arrow-down{% else %}fi-arrow-up{% endif %}{% endif %} right"></i>
-                        </a>
-                    </th>
-                    {% endfor %}
-                </tr>
-            </thead>
-            <tbody>
-                {% for participant in participant_list %}
-                <tr>
-                    {% for column in columns %}
-                    <td>
-                        {% if column.label == "STATUS" %}
-                            <span class="label label-{{participant|get_item:column.name}}">
-                                {{participant|get_item:column.name}}
+{#    {% if not allow_organizer_teams %}#}
+        {% if not object_list %}
+            <p><em>There are no participants.</em></p>
+        {% else %}
+            {% if not allow_organizer_teams %}
+                {% for item in pending_participants %}
+                    <div class="panel panel-default competitionUserBlock competitionUserBlock_{{ item.id }}">
+                        <div class="panel-heading">
+                            <h3 class="panel-title">{{ item.user.username }}
+                                <span class="participationStatus label label-{{ item.status.codename }}">
+                                {% if item.status.codename == 'pending' %}
+                                    Participation pending approval
+                                {% elif item.status.codename == 'approved' %}
+                                    Participation approved
+                                {% elif item.status.codename == 'denied' %}
+                                    Participation denied
+                                {% else %}
+                                    Unknown Status
+                                {% endif %}
                             </span>
-                            <button type="button" class="pull-right btn btn-danger btn-sm revoke_button button {% if participant.status == "denied" %}hide{% endif %}" participant_id="{{ participant.pk }}">Revoke</button>
-                            <button type="button" class="pull-right btn btn-success btn-sm reinstate_button button {% if participant.status == "approved" %}hide{% endif %}" participant_id="{{ participant.pk }}">Reinstate</button>
-                        {% else %}
-                            {{ participant|get_item:column.name }}
-                        {% endif %}
-                    </td>
+                            </h3>
+                        </div>
+                        <div class="panel-body">
+                            {% if item.status.codename == 'denied' %}
+                                <p class="text-danger">Reason: {{ item.reason }}</p>
+                            {% endif %}
+                            <form class="custom process_request" id="process_request_{{ item.id }}">{% csrf_token %}
+                                <input type="hidden" name="participant_id" value="{{ item.id }}"/>
+                                <div class="row">
+                                    <div class="col-sm-4">
+                                        <div class="form-group">
+                                            <label for="status">Status:</label>
+                                            <select id="status" name="status" class="form-control">
+                                                <option value="approved">Approve</option>
+                                                <option value="denied">Deny</option>
+                                            </select>
+                                        </div>
+                                    </div>
+                                    <div class="col-sm-8">
+                                        <div class="form-group">
+                                            <label for="reason">Reason:</label>
+                                            <textarea id="reason" name="reason" class="form-control"></textarea>
+                                        </div>
+                                    </div>
+                                </div>
+                                <input type="submit" class="btn btn-primary pull-right" value="Process"/>
+                            </form>
+                        </div>
+                    </div>
+                {% endfor %}
+            {% endif %}
+
+            <button type="button" data-toggle="modal" href="#message_all_modal" class="btn btn-primary">Send message to
+                all participants?
+            </button>
+
+            <table class="resultsTable dataTable table table-striped table-bordered">
+                <thead>
+                <tr>
+                    {% for column in columns %}
+                        <th>
+                            <a href="?order=
+                                    {{ column.name }}{% if direction == 'asc' and order == column.name %}&direction=desc{% endif %}">
+                                {{ column.label }} <i class="
+                                    {% if order == column.name %}{% if direction == 'asc' %}fi-arrow-down{% else %}fi-arrow-up{% endif %}{% endif %} right"></i>
+                            </a>
+                        </th>
                     {% endfor %}
                 </tr>
+                </thead>
+                <tbody>
+                {% for participant in participant_list %}
+                    <tr>
+                        {% for column in columns %}
+                            <td>
+                                {% if column.label == "STATUS" %}
+                                    <span class="label label-{{ participant|get_item:column.name }}">
+                                    {{ participant|get_item:column.name }}
+                                </span>
+                                    {% if not allow_organizer_teams %}
+                                        <button type="button"
+                                                class="pull-right btn btn-danger btn-sm revoke_button button {% if participant.status == "denied" %}hide{% endif %}"
+                                                participant_id="{{ participant.pk }}">Revoke
+                                        </button>
+                                        <button type="button"
+                                                class="pull-right btn btn-success btn-sm reinstate_button button {% if participant.status == "approved" %}hide{% endif %}"
+                                                participant_id="{{ participant.pk }}">Reinstate
+                                        </button>
+                                    {% endif %}
+                                {% else %}
+                                    {{ participant|get_item:column.name }}
+                                {% endif %}
+                            </td>
+                        {% endfor %}
+                    </tr>
                 {% endfor %}
-            </tbody>
-        </table>
+                </tbody>
+            </table>
         {% endif %}
+{#    {% endif %}#}
     </div>
 </div>
 <div class="modal fade" id="message_all_modal">

--- a/codalab/apps/web/templates/web/my/participants.html
+++ b/codalab/apps/web/templates/web/my/participants.html
@@ -15,12 +15,7 @@
 <a href="{% url "competitions:view" pk=competition_id %}" class="pull-right" >Go Back to Competition Homepage</a>
 {% if allow_organizer_teams %}
     <a href="{% url "create_org_team" competition_pk=competition_id %}" class="pull-middle btn btn-default" >Create Organizer Team</a>
-    {{ csv_form.non_field_errors }}
-    <form action="{% url "create_org_teams_from_csv" competition_pk=competition_id %}" method="POST" enctype="multipart/form-data">
-        {% csrf_token %}
-        {{ csv_form.as_p }}
-        <input type="submit" value="Submit">
-    </form>
+    <a href="{% url "create_org_teams_from_csv" competition_pk=competition_id %}" class="pull-middle btn btn-default" >Upload Team CSV</a>
 {% endif %}
 
 <div class="participants">
@@ -436,6 +431,15 @@
 
         };
     });
+
+$( document ).ready(function() {
+    $("#submit_button").click(function () {
+        $('#id_csv_file').click();
+    });
+    $('#id_csv_file').change(function(){
+        $('#choose-file').submit()
+    })
+});
 
     function removeErrorMessage(){
         $('#subject-alert').css({

--- a/codalab/apps/web/urls/competitions.py
+++ b/codalab/apps/web/urls/competitions.py
@@ -35,5 +35,5 @@ urlpatterns = patterns(
     url(r'^(?P<pk>\d+)/public_submissions/(?P<phase>\d+)$', views.CompetitionPublicSubmissionByPhases.as_view(), name='public_submissions_phase'),
     url(r'^(?P<competition_pk>\d+)/dumps/$', views.competition_dumps_view, name='dumps'),
     url(r'^(?P<pk>\d+)/delete_dump/$', views.CompetitionDumpDeleteView.as_view(), name="delete_dump"),
-
+    url(r'^(?P<competition_pk>\d+)/create_org_team/$', views.CompetitionOrganizerTeams.as_view(), name='create_org_team'),
 )

--- a/codalab/apps/web/urls/competitions.py
+++ b/codalab/apps/web/urls/competitions.py
@@ -35,5 +35,4 @@ urlpatterns = patterns(
     url(r'^(?P<pk>\d+)/public_submissions/(?P<phase>\d+)$', views.CompetitionPublicSubmissionByPhases.as_view(), name='public_submissions_phase'),
     url(r'^(?P<competition_pk>\d+)/dumps/$', views.competition_dumps_view, name='dumps'),
     url(r'^(?P<pk>\d+)/delete_dump/$', views.CompetitionDumpDeleteView.as_view(), name="delete_dump"),
-    url(r'^(?P<competition_pk>\d+)/create_org_team/$', views.CompetitionOrganizerTeams.as_view(), name='create_org_team'),
 )

--- a/codalab/apps/web/views.py
+++ b/codalab/apps/web/views.py
@@ -1040,7 +1040,7 @@ class MyCompetitionParticipantView(LoginRequiredMixin, ListView):
                     'name': team.name,
                     'creator': team.creator.username,
                     'creator_pk': team.creator.pk,
-                    'num_members': 0,
+                    'num_members': team.members.count(),
                     'num_pending': 0,
                     'status': team.status.codename,
                     'number': number + 1,

--- a/codalab/apps/web/views.py
+++ b/codalab/apps/web/views.py
@@ -1002,7 +1002,10 @@ class MyCompetitionParticipantView(LoginRequiredMixin, ListView):
         context['pending_participants'] = filter(lambda participant_submission: participant_submission.status.codename == models.ParticipantStatus.PENDING, competition_participants)
         participant_submissions = models.CompetitionSubmission.objects.filter(participant__in=competition_participants_ids)
         for number, participant in enumerate(competition_participants):
-            team = get_user_team(participant, participant.competition)
+            # team = get_user_team(participant, participant.competition)
+            # We should only get returned 1 team: We filter in case this logic fails.
+            membership = TeamMembership.objects.filter(user=participant.user, team__competition=competition).first()
+            team = membership.team
             if team is not None:
                 team_name = team.name
             else:

--- a/codalab/apps/web/views.py
+++ b/codalab/apps/web/views.py
@@ -1002,10 +1002,7 @@ class MyCompetitionParticipantView(LoginRequiredMixin, ListView):
         context['pending_participants'] = filter(lambda participant_submission: participant_submission.status.codename == models.ParticipantStatus.PENDING, competition_participants)
         participant_submissions = models.CompetitionSubmission.objects.filter(participant__in=competition_participants_ids)
         for number, participant in enumerate(competition_participants):
-            # team = get_user_team(participant, participant.competition)
-            # We should only get returned 1 team: We filter in case this logic fails.
-            membership = TeamMembership.objects.filter(user=participant.user, team__competition=competition).first()
-            team = membership.team
+            team = get_user_team(participant.user, participant.competition)
             if team is not None:
                 team_name = team.name
             else:


### PR DESCRIPTION
Features for A-Teams:
 - Competition `Allow Organizer Teams` option
 - Remove Teams tab/participation approval
 - Add Create Organizer Team Button/Form/View/Template
 - Add Create Organizer Team from CSV Button/Form/View/Template
 - Added logic to `Team` save to prevent users from having more than 1 `TeamMembership` Object per `Competition`.
 - Add validation/error handling to forms