### PR TITLE
GPDR Email Settings

### DIFF
--- a/codalab/apps/authenz/migrations/0011_auto__add_field_cluser_allow_admin_status_updates.py
+++ b/codalab/apps/authenz/migrations/0011_auto__add_field_cluser_allow_admin_status_updates.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'ClUser.allow_admin_status_updates'
+        db.add_column(u'authenz_cluser', 'allow_admin_status_updates',
+                      self.gf('django.db.models.fields.BooleanField')(default=True),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'ClUser.allow_admin_status_updates'
+        db.delete_column(u'authenz_cluser', 'allow_admin_status_updates')
+
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'authenz.cluser': {
+            'Meta': {'object_name': 'ClUser'},
+            'allow_admin_status_updates': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'bibtex': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'contact_email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'null': 'True', 'blank': 'True'}),
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'email_on_submission_finished_successfully': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'method_description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'method_name': ('django.db.models.fields.CharField', [], {'max_length': '20', 'null': 'True', 'blank': 'True'}),
+            'organization_or_affiliation': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'organizer_direct_message_updates': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'organizer_status_updates': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'participation_status_updates': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'project_url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'publication_url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'rabbitmq_password': ('django.db.models.fields.CharField', [], {'max_length': '36', 'null': 'True', 'blank': 'True'}),
+            'rabbitmq_queue_limit': ('django.db.models.fields.PositiveIntegerField', [], {'default': '5', 'blank': 'True'}),
+            'rabbitmq_username': ('django.db.models.fields.CharField', [], {'max_length': '36', 'null': 'True', 'blank': 'True'}),
+            'team_members': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'team_name': ('django.db.models.fields.CharField', [], {'max_length': '64', 'null': 'True', 'blank': 'True'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30', 'db_index': 'True'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        }
+    }
+
+    complete_apps = ['authenz']

--- a/codalab/apps/authenz/models.py
+++ b/codalab/apps/authenz/models.py
@@ -11,6 +11,7 @@ class ClUser(auth_models.AbstractUser):
     organizer_status_updates = models.BooleanField(default=True)
     organizer_direct_message_updates = models.BooleanField(default=True)
     email_on_submission_finished_successfully = models.BooleanField(default=False)
+    allow_admin_status_updates = models.BooleanField(default=True)
 
     # Profile details
     organization_or_affiliation = models.CharField(max_length=255, null=True, blank=True)

--- a/codalab/apps/web/forms.py
+++ b/codalab/apps/web/forms.py
@@ -248,6 +248,7 @@ class UserSettingsForm(forms.ModelForm):
             'participation_status_updates',
             'organizer_status_updates',
             'organizer_direct_message_updates',
+            'allow_admin_status_updates',
             'organization_or_affiliation',
             'email_on_submission_finished_successfully',
             'team_name',

--- a/codalab/apps/web/templates/web/my/settings.html
+++ b/codalab/apps/web/templates/web/my/settings.html
@@ -100,6 +100,10 @@
                         <th>{{ form.email_on_submission_finished_successfully.label }}</th>
                         <td>{{ form.email_on_submission_finished_successfully }}</td>
                     </tr>
+                    <tr>
+                        <th>{{ form.allow_admin_status_updates.label }}</th>
+                        <td>{{ form.allow_admin_status_updates }}</td>
+                    </tr>
                 </tbody>
             </table>
         </div>

--- a/codalab/apps/web/tests/test_notifications.py
+++ b/codalab/apps/web/tests/test_notifications.py
@@ -143,6 +143,21 @@ class CompetitionMessageParticipantsTests(CompetitionTest):
 
         self.assertFalse(send_mass_email_mock.called)
 
+    def test_msg_participants_email_not_sent_when_participant_disables_admin_status_updates(self):
+        self.participant_user.allow_admin_status_updates = False
+        self.participant_user.save()
+
+        self.client.login(username="organizer", password="pass")
+
+        with mock.patch('apps.web.tasks.send_mass_email.apply_async') as send_mass_email_mock:
+            resp = self.client.post(
+                reverse("competitions:competition_message_participants", kwargs={"competition_id": self.competition.pk}),
+                data={"subject": "test", "body": 'Test body'}
+            )
+            self.assertEquals(resp.status_code, 200)
+
+        self.assertFalse(send_mass_email_mock.called)
+
     def test_msg_participants_email_not_sent_to_denied_participants(self):
         self.participant.status = ParticipantStatus.objects.get(codename=ParticipantStatus.APPROVED)
         self.participant.save()

--- a/codalab/apps/web/tests/test_notifications.py
+++ b/codalab/apps/web/tests/test_notifications.py
@@ -143,21 +143,6 @@ class CompetitionMessageParticipantsTests(CompetitionTest):
 
         self.assertFalse(send_mass_email_mock.called)
 
-    def test_msg_participants_email_not_sent_when_participant_disables_admin_status_updates(self):
-        self.participant_user.allow_admin_status_updates = False
-        self.participant_user.save()
-
-        self.client.login(username="organizer", password="pass")
-
-        with mock.patch('apps.web.tasks.send_mass_email.apply_async') as send_mass_email_mock:
-            resp = self.client.post(
-                reverse("competitions:competition_message_participants", kwargs={"competition_id": self.competition.pk}),
-                data={"subject": "test", "body": 'Test body'}
-            )
-            self.assertEquals(resp.status_code, 200)
-
-        self.assertFalse(send_mass_email_mock.called)
-
     def test_msg_participants_email_not_sent_to_denied_participants(self):
         self.participant.status = ParticipantStatus.objects.get(codename=ParticipantStatus.APPROVED)
         self.participant.save()

--- a/codalab/apps/web/views.py
+++ b/codalab/apps/web/views.py
@@ -434,7 +434,6 @@ def competition_message_participants(request, competition_id):
         competition=competition,
         status=models.ParticipantStatus.objects.get(codename="approved"),
         user__organizer_direct_message_updates=True,
-        user__allow_admin_status_updates=True,
     )
     emails = [p.user.email for p in participants]
     subject = request.POST.get('subject')

--- a/codalab/apps/web/views.py
+++ b/codalab/apps/web/views.py
@@ -433,7 +433,8 @@ def competition_message_participants(request, competition_id):
     participants = models.CompetitionParticipant.objects.filter(
         competition=competition,
         status=models.ParticipantStatus.objects.get(codename="approved"),
-        user__organizer_direct_message_updates=True
+        user__organizer_direct_message_updates=True,
+        user__allow_admin_status_updates=True,
     )
     emails = [p.user.email for p in participants]
     subject = request.POST.get('subject')


### PR DESCRIPTION
- Adds `allow_admin_status_updates` to user model
- Filters participants's emails on mass mail to exclude those with the setting disabled
- Adds a test for this