### PR TITLE
Competition Dumps: Fix Null instead of False

### DIFF
--- a/codalab/apps/web/tasks.py
+++ b/codalab/apps/web/tasks.py
@@ -853,11 +853,11 @@ def do_phase_migrations():
 
 def _get_or_default(obj, field_name, default=None):
     if hasattr(obj, field_name):
-        if getattr(obj, field_name):
+        if getattr(obj, field_name) != None:
             return getattr(obj, field_name)
-    elif default:
+    if default != None:
         return default
-    elif obj._meta.get_field(field_name).get_default():
+    elif obj._meta.get_field(field_name).get_default() != None:
         return obj._meta.get_field(field_name).get_default()
     else:
         return None


### PR DESCRIPTION
Fix logic in the if/else conditions of the competition dump default value helper to not return `None` if the default value is `False`.

To-Do:
 - [ ] Fix ambiguous error concerning missing HTML keys 