### PR TITLE
Better Error on Comp Upload if no `data` key

### DIFF
--- a/codalab/apps/web/models.py
+++ b/codalab/apps/web/models.py
@@ -1780,15 +1780,18 @@ class CompetitionDefBundle(models.Model):
                 )
 
         participate_category = ContentCategory.objects.get(name="Participate")
-        Page.objects.create(
-            category=participate_category,
-            container=pc,
-            codename="get_data",
-            competition=comp,
-            label="Get Data",
-            rank=0,
-            html=zf.read(comp_spec['html']['data'])
-        )
+        try:
+            Page.objects.create(
+                category=participate_category,
+                container=pc,
+                codename="get_data",
+                competition=comp,
+                label="Get Data",
+                rank=0,
+                html=zf.read(comp_spec['html']['data'])
+            )
+        except KeyError:
+            assert False, "No HTML file with key `data` specified. This is required."
         Page.objects.create(
             category=participate_category,
             container=pc,


### PR DESCRIPTION
Gives a better error message instead of just `data`.

![image](https://user-images.githubusercontent.com/28552312/42239958-867cd91e-7eba-11e8-8495-e5ffcea601cb.png)

(Changed error to read: ```No HTML file with key `data` specified. This is required.```)