### PR TITLE
Check for Webpage name duplication. Returns error if name is a duplic…

### DIFF
--- a/codalab/apps/web/forms.py
+++ b/codalab/apps/web/forms.py
@@ -150,13 +150,7 @@ class PageForm(forms.ModelForm):
                 label=label
             ).exclude(pk=self.instance.pk)
             if existing_website.exists():
-                raise forms.ValidationError(
-                    {
-                        'name': ['Invalid value for website name. A website already exists with that name.']
-                    },
-                    code='invalid'
-                )
-
+                raise forms.ValidationError('Website Name is invalid. This name is already in use.', code='invalid')
         return label
 
     def save(self, commit=True):

--- a/codalab/apps/web/forms.py
+++ b/codalab/apps/web/forms.py
@@ -1,6 +1,7 @@
 import os
 
 from django import forms
+from django.core.exceptions import ValidationError
 from django.core.files.base import ContentFile
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.auth import get_user_model
@@ -139,6 +140,24 @@ class PageForm(forms.ModelForm):
         widgets = { 'html' : TinyMCE(attrs={'rows' : 20, 'class' : 'competition-editor-page-html'},
                                      mce_attrs={"theme" : "advanced", "cleanup_on_startup" : True, "theme_advanced_toolbar_location" : "top", "gecko_spellcheck" : True}),
                     'DELETE' : forms.HiddenInput, 'container' : forms.HiddenInput}
+
+    def clean_label(self):
+        cleaned_data = super(PageForm, self).clean()
+        label = cleaned_data.get('label')
+        if label:
+            existing_website = models.Page.objects.filter(
+                competition=self.instance.competition,
+                label=label
+            ).exclude(pk=self.instance.pk)
+            if existing_website.exists():
+                raise forms.ValidationError(
+                    {
+                        'name': ['Invalid value for website name. A website already exists with that name.']
+                    },
+                    code='invalid'
+                )
+
+        return label
 
     def save(self, commit=True):
 

--- a/codalab/apps/web/templates/web/competitions/edit.html
+++ b/codalab/apps/web/templates/web/competitions/edit.html
@@ -137,7 +137,9 @@
                                         <div class="col-sm-9">
                                             <div class="field-container page-container">
                                                 {{ field }}
-                                                {{ field.errors }}
+                                                <div class="form-group {% if field.errors %}alert alert-danger{% endif %}">
+                                                    {{ field.errors }}
+                                                </div>
                                             </div>
                                         </div>
                                     {% endif %}
@@ -304,6 +306,20 @@
         </div>
     </div>
 </form>
+
+<style>
+    .alert-danger {
+        width: 100%;
+        margin-top: 0.5em;
+        margin-left: 0 !important;
+        margin-bottom: -5px;
+    }
+
+    .errorlist {
+        list-style-type: none;
+        text-align: left;
+    }
+</style>
 {% endblock content %}
 
 {% block jsincludes %}


### PR DESCRIPTION
Resolves #2300 

The purpose of this PR is to check if a Web page name is a duplicate of a Web page name already used in the competition. If the name is a duplicate, it will return the user to the form with a field-errror.