### PR TITLE
FIX: show/hide and failed buttons update the wrong columns in submissions.html

### DIFF
--- a/codalab/apps/web/templates/web/my/submissions.html
+++ b/codalab/apps/web/templates/web/my/submissions.html
@@ -205,7 +205,7 @@
                     var pk = parent_tr.prop('id');
                     $.post("/competitions/mark_as_failed/" + pk)
                         .success(function () {
-                            parent_tr.find('td:nth-child(4)').text('Failed');
+                            parent_tr.find('td:nth-child(6)').text('Failed');
                         })
                         .error(function () {
                             alert("Failed to mark submission as failed, is your Internet connection working? If this problem persists contact an admin.");
@@ -216,16 +216,16 @@
             $(".hide_or_show_submission_button").click(function () {
                 var self = this;
                 var parent_tr = $(this).parents('tr');
-                var old_state = parent_tr.find('td:nth-child(5)').text();
+                var old_state = parent_tr.find('td:nth-child(7)').text();
                 var pk = parent_tr.prop('id');
                 $.post("/competitions/toggle_leaderboard/" + pk)
                     .success(function () {
                         // toggle "Leaderboard" column label
                         if (old_state.indexOf("True") != -1) {
-                            parent_tr.find('td:nth-child(5)').text('False');
+                            parent_tr.find('td:nth-child(7)').text('False');
                             $(self).text('SHOW');
                         } else {
-                            parent_tr.find('td:nth-child(5)').text('True');
+                            parent_tr.find('td:nth-child(7)').text('True');
                             $(self).text('HIDE');
                         }
                     })


### PR DESCRIPTION
This PRs makes sure the right columns are changes when the `show`/`hide` and `failed` buttons are click on the submissions page.

Before clicking the `show` button.
![before](https://user-images.githubusercontent.com/660004/49560415-4cd21800-f8e0-11e8-9be9-ec5ff7c6df5d.png)
After
![after](https://user-images.githubusercontent.com/660004/49560420-53608f80-f8e0-11e8-9715-d41d871c071e.png)

NB: I didn't test the changes as I'm not running in instance of CodaLab.