### PR TITLE
FIX: chart high score doesn't respect sorting

### DIFF
--- a/codalab/apps/web/views.py
+++ b/codalab/apps/web/views.py
@@ -550,9 +550,9 @@ class CompetitionDetailView(DetailView):
                     qs = SubmissionScore.objects.filter(result__phase__competition=competition, scoredef=score_def)
                     qs = qs.extra({'day': truncate_date}).values('day')
                     if score_def.sorting == 'asc':
-                        best_value = Max('value')
-                    else:
                         best_value = Min('value')
+                    else:
+                        best_value = Max('value')
                     qs = qs.annotate(high_score=best_value, count=Count('pk'))
                     context['graph'] = {
                         'days': [s['day'].strftime('%d %B %Y')  # ex 24 May 2017


### PR DESCRIPTION
At the moment, high scores displayed in the chart are wrong, i.e. they don't respect the sorting specified for the metric.

This PR fixes #2462.

As an example, see https://competitions.codalab.org/competitions/20865#results where all the high in the chart are 0 while in the leaderboard table we clearly see submissions with high scores in the hundreds.

![image](https://user-images.githubusercontent.com/660004/50849294-93ce8580-1344-11e9-88f2-e89f675f9dc9.png)
