### PR TITLE
Send Chahub General Stats (#2343)

### DIFF
--- a/codalab/apps/chahub/models.py
+++ b/codalab/apps/chahub/models.py
@@ -9,6 +9,7 @@ from django.conf import settings
 from django.db import models, IntegrityError
 from django.utils import timezone
 
+from apps.chahub.utils import send_to_chahub
 
 logger = logging.getLogger(__name__)
 
@@ -68,29 +69,6 @@ class ChaHubSaveMixin(models.Model):
     # -------------------------------------------------------------------------
     # Regular methods
     # -------------------------------------------------------------------------
-    def get_chahub_url(self):
-        assert settings.CHAHUB_API_URL, "No ChaHub URL given, cannot send details to ChaHub"
-        assert settings.CHAHUB_API_URL.endswith("/"), "ChaHub API url must end with a slash"
-
-        endpoint = self.get_chahub_endpoint()
-        assert endpoint, Exception("No ChaHub API endpoint given")
-
-        return "{}{}".format(settings.CHAHUB_API_URL, endpoint)
-
-    def send_to_chahub(self, data):
-        """Sends data to chahub and returns the HTTP response"""
-        url = self.get_chahub_url()
-
-        logger.info("ChaHub :: Sending to ChaHub ({}) the following data: \n{}".format(url, data))
-
-        try:
-            return requests.post(url, data, headers={
-                'Content-type': 'application/json',
-                'X-CHAHUB-API-KEY': settings.CHAHUB_API_KEY,
-            })
-        except requests.ConnectionError:
-            return None
-
     def save(self, force_to_chahub=False, *args, **kwargs):
         # We do a save here to give us an ID for generating URLs and such
         try:
@@ -117,7 +95,7 @@ class ChaHubSaveMixin(models.Model):
 
                 # Send to chahub if we haven't yet, we have new data
                 if not self.chahub_timestamp or self.chahub_data_hash != data_hash:
-                    resp = self.send_to_chahub(data)
+                    resp = send_to_chahub(self.get_chahub_endpoint(), data)
 
                     if resp and resp.status_code in (200, 201):
                         logger.info("ChaHub :: Received response {} {}".format(resp.status_code, resp.content))

--- a/codalab/apps/chahub/tests/test_chahub_mixin.py
+++ b/codalab/apps/chahub/tests/test_chahub_mixin.py
@@ -38,7 +38,7 @@ class ChahubMixinTests(TestCase):
 
     def test_submission_mixin_save_doesnt_resend_same_data(self):
         submission = CompetitionSubmission(phase=self.phase, participant=self.participant)
-        with mock.patch('apps.web.models.CompetitionSubmission.send_to_chahub') as send_to_chahub_mock:
+        with mock.patch('apps.chahub.models.send_to_chahub') as send_to_chahub_mock:
             send_to_chahub_mock.return_value = HttpResponseBase(status=201)
             send_to_chahub_mock.return_value.content = ""
             submission.save()
@@ -70,14 +70,14 @@ class ChahubMixinTests(TestCase):
 
         # Mark submission for retry
         submission = CompetitionSubmission(phase=self.phase, participant=self.participant, chahub_needs_retry=True)
-        with mock.patch('apps.web.models.CompetitionSubmission.send_to_chahub') as send_to_chahub_mock:
+        with mock.patch('apps.chahub.models.send_to_chahub') as send_to_chahub_mock:
             submission.save()
             assert not send_to_chahub_mock.called
 
     def test_submission_valid_not_retried_again(self):
         # Mark submission for retry
         submission = CompetitionSubmission(phase=self.phase, participant=self.participant, chahub_needs_retry=True)
-        with mock.patch('apps.web.models.CompetitionSubmission.send_to_chahub') as send_to_chahub_mock:
+        with mock.patch('apps.chahub.models.send_to_chahub') as send_to_chahub_mock:
             send_to_chahub_mock.return_value = HttpResponseBase(status=201)
             send_to_chahub_mock.return_value.content = ""
             submission.save()  # NOTE! not called with force_to_chahub=True as retrying would set
@@ -87,7 +87,7 @@ class ChahubMixinTests(TestCase):
     def test_submission_retry_valid_retried_then_sent_and_not_retried_again(self):
         # Mark submission for retry
         submission = CompetitionSubmission(phase=self.phase, participant=self.participant, chahub_needs_retry=True)
-        with mock.patch('apps.web.models.CompetitionSubmission.send_to_chahub') as send_to_chahub_mock:
+        with mock.patch('apps.chahub.models.send_to_chahub') as send_to_chahub_mock:
             send_to_chahub_mock.return_value = HttpResponseBase(status=201)
             send_to_chahub_mock.return_value.content = ""
             submission.save(force_to_chahub=True)

--- a/codalab/apps/chahub/tests/test_chahub_utils.py
+++ b/codalab/apps/chahub/tests/test_chahub_utils.py
@@ -1,0 +1,44 @@
+import datetime
+import mock
+from django.conf import settings
+
+from django.test import TestCase
+from django.test.utils import override_settings
+
+from apps.authenz.models import ClUser
+from apps.web.models import CompetitionSubmission, Competition, CompetitionPhase, CompetitionParticipant, \
+    ParticipantStatus
+from apps.web.tasks import send_chahub_general_stats
+
+
+class ChahubUtillityTests(TestCase):
+    def setUp(self):
+        self.user = ClUser.objects.create_user(username="user", password="pass")
+        self.competition = Competition.objects.create(
+            title="Test Competition",
+            creator=self.user,
+            modified_by=self.user,
+            published=True,
+        )
+        self.participant = CompetitionParticipant.objects.create(
+            user=self.user,
+            competition=self.competition,
+            status=ParticipantStatus.objects.get_or_create(name='approved', codename=ParticipantStatus.APPROVED)[0],
+        )
+        self.phase = CompetitionPhase.objects.create(
+            competition=self.competition,
+            phasenumber=1,
+            start_date=datetime.datetime.now() - datetime.timedelta(days=30),
+        )
+
+    @override_settings(CHAHUB_API_URL='http://host.docker.internal/')
+    def test_send_to_chahub_utillity(self):
+        # with mock.patch('apps.web.models.CompetitionSubmission.send_to_chahub') as send_to_chahub_mock:
+        with mock.patch('apps.web.tasks.send_to_chahub') as send_to_chahub_mock:
+            send_to_chahub_mock.return_value = None
+            # Calling this as a function instead of a task?
+            send_chahub_general_stats()
+            # attempts to send to Chahub once
+            # We succesfully sent data to Chahub
+            assert send_to_chahub_mock.called
+

--- a/codalab/apps/chahub/utils.py
+++ b/codalab/apps/chahub/utils.py
@@ -1,0 +1,39 @@
+from django.conf import settings
+
+import logging
+import os
+import requests
+import json
+
+logger = logging.getLogger(__name__)
+
+
+def send_to_chahub(endpoint, data, update=False):
+    """
+    Does a post request to the specified API endpoint on chahub with the inputted data.
+    :param endpoint: String designating which API endpoint; IE: 'producers/'
+    :param data: Dictionary containing data we are sending away to the endpoint.
+    :return:
+    """
+    assert endpoint, Exception("No ChaHub API endpoint given")
+    assert settings.CHAHUB_API_URL, "CHAHUB_API_URL env var required to send to Chahub "
+
+    url = "{}{}".format(settings.CHAHUB_API_URL, endpoint)
+
+    data = json.dumps(data)
+
+    logger.info("ChaHub :: Sending to ChaHub ({}) the following data: \n{}".format(url, data))
+    try:
+        kwargs = {
+            'url': url,
+            'headers': {
+                'Content-type': 'application/json',
+                'X-CHAHUB-API-KEY': settings.CHAHUB_API_KEY,
+            }
+        }
+        if update:
+            return requests.patch(data=data, **kwargs)
+        else:
+            return requests.put(data=data, **kwargs)
+    except requests.ConnectionError:
+        return None

--- a/codalab/codalab/settings/base.py
+++ b/codalab/codalab/settings/base.py
@@ -447,8 +447,12 @@ class Base(Settings):
             'task': 'apps.web.tasks.do_chahub_retries',
             'schedule': timedelta(seconds=60 * 10),
         },
-        'chahub_participant_counts': {
-            'task': 'apps.web.tasks.send_chahub_updates',
+        'chahub_competition_updates': {
+            'task': 'apps.web.tasks.send_chahub_competition_updates',
+            'schedule': timedelta(seconds=60 * 60 * 24),
+        },
+        'chahub_general_statistics': {
+            'task': 'apps.web.tasks.send_chahub_general_stats',
             'schedule': timedelta(seconds=60 * 60 * 24),
         },
     }
@@ -472,7 +476,9 @@ class Base(Settings):
     # =========================================================================
     CHAHUB_API_URL = os.environ.get('CHAHUB_API_URL')
     CHAHUB_API_KEY = os.environ.get('CHAHUB_API_KEY')
+    CHAHUB_PRODUCER_ID = os.environ.get('CHAHUB_PRODUCER_ID')
 
+    assert CHAHUB_API_URL.endswith("/"), "ChaHub API url must end with a slash"
 
     # =========================================================================
     # Logging


### PR DESCRIPTION
* Add task to send chahub general stats, add to celery beat schedule.

* Move CHAHUB API URL check to settings, abstract chahub_send_data process in utils, etc

* Update branch with current develop, address PR comments, fix up test, test still not passing

* PR Comment Changes: Only count published competitions and approved users

* Remove _chahub_send_data()

* fixes some DRY violations when sending general stats

* pass endpoint with data

* fix mock reference, move to DRY send_to_chahub method

* properly get participant counts

* fix mock for general chahub test

* Point send_chahub_stats to producers endpoint, patch instead of put, CHAHUB_PRODUCER_ID in .env required