### PR TITLE
Allauth fix

### DIFF
--- a/codalab/requirements/common.txt
+++ b/codalab/requirements/common.txt
@@ -80,3 +80,5 @@ pytest-watch==4.1.0
 pytest-env==0.6.2
 
 lxml==4.1.1
+
+certifi==2019.3.9

--- a/codalab/requirements/common.txt
+++ b/codalab/requirements/common.txt
@@ -60,7 +60,10 @@ gunicorn==19.7.0
 git+https://github.com/Tthomas63/django-switchuser.git@eb8b71622201f66ef1862a4976c12ef83145b5e8
 Sphinx==1.4.1
 
-#django-allauth==0.11.1
+# django-allauth==0.11.1
+# Patched a vulnerability in allauth. The login view redirects to the next parameter in the url after successful form validation. Before, there was 
+# minimal validation, so it could be manually changed in the browser to any host. Now, it is checked against django.utils.is_safe_url before the 
+# redirect occurs.
 git+https://github.com/gibsonbailey/django-allauth.git@codalab
 
 # Added for python sdk

--- a/codalab/requirements/common.txt
+++ b/codalab/requirements/common.txt
@@ -4,7 +4,6 @@ anyjson==0.3.3
 argparse
 # azure==0.7.1
 closure_linter
-django-allauth==0.11.1
 django-analytical==0.15.0
 django-appconf==0.6
 django-compressor==1.3
@@ -61,6 +60,8 @@ gunicorn==19.7.0
 git+https://github.com/Tthomas63/django-switchuser.git@eb8b71622201f66ef1862a4976c12ef83145b5e8
 Sphinx==1.4.1
 
+#django-allauth==0.11.1
+git+https://github.com/gibsonbailey/django-allauth.git@codalab
 
 # Added for python sdk
 git+https://github.com/FlavioAlexander/azure-sdk-for-python.git@legacy
@@ -79,5 +80,3 @@ pytest-watch==4.1.0
 pytest-env==0.6.2
 
 lxml==4.1.1
-
-certifi==2019.3.9


### PR DESCRIPTION
The allauth package contained a login view that was vulnerable to phishing. This points to a forked repo where the vulnerability has been patched for the correct version of allauth.