### PR TITLE
Make method details available via REST API

### DIFF
--- a/codalab/apps/api/serializers.py
+++ b/codalab/apps/api/serializers.py
@@ -49,7 +49,7 @@ class CompetitionSubmissionSerial(serializers.ModelSerializer):
     filename = serializers.Field(source="get_filename")
     class Meta:
         model = webmodels.CompetitionSubmission
-        fields = ('id','status','status_details','submitted_at','submission_number', 'file', 'filename', 'exception_details', 'description')
+        fields = ('id','status','status_details','submitted_at','submission_number', 'file', 'filename', 'exception_details', 'description', 'method_name', 'method_description', 'project_url', 'publication_url', 'bibtex', 'organization_or_affiliation')
         read_only_fields = ('participant', 'phase', 'id','status_details','submitted_at','submission_number', 'exception_details')
 
 class PhaseSerial(serializers.ModelSerializer):


### PR DESCRIPTION
Hi,

since I also wanted to access the method details via the API (see issue  #2655) and I couldn't find an appropriate API call, I investigated the problem.

I think that the changes to the serializer would make the meta information available. I hope that the changes don't break anything. It would be nice to have also the meta information available.

