### PR TITLE
Removes submission limits on chagrade_bot user.

### DIFF
--- a/codalab/apps/web/models.py
+++ b/codalab/apps/web/models.py
@@ -1439,6 +1439,8 @@ class CompetitionSubmission(ChaHubSaveMixin, models.Model):
 
         # only at save on object creation should it be submitted
         if not self.pk:
+            if self.participant.user.username == 'chagrade_bot':
+                ignore_submission_limits = True
             if not ignore_submission_limits:
                 print "This is a new submission, getting the submission number."
                 subnum = CompetitionSubmission.objects.filter(phase=self.phase, participant=self.participant).aggregate(Max('submission_number'))['submission_number__max']


### PR DESCRIPTION
Chagrade limits student's submissions, but the Codalab bot should not be limited.