### PR TITLE
Add a superuser or staff condition to rerun all submission button

### DIFF
--- a/codalab/apps/web/templates/web/my/submissions.html
+++ b/codalab/apps/web/templates/web/my/submissions.html
@@ -181,7 +181,7 @@
                                     Select a phase to view details & run actions against it<br>
                                 </span>
 
-                                <v-btn
+                                <v-btn v-if="is_superuser_or_staff"
                                         :disabled="!phase"
                                         @click="re_run_all_submissions"
                                 >
@@ -434,6 +434,7 @@
     <script>
         $(document).ready(function () {
             var COMPETITION_ID = {{ competition.id }}
+            var IS_SUPERUSER_OR_STAFF = {{is_superuser_or_staff|yesno:"true,false" }}
                 {#var PHASE_ID = {{ selected_phase.id }}#}
                 new Vue({
                     el: '#app',
@@ -463,7 +464,8 @@
                             submissions: [],
                             phase: null,
                             phases: [],
-                            loading: true
+                            loading: true,
+                            is_superuser_or_staff: IS_SUPERUSER_OR_STAFF
                         }
                     },
                     computed: {

--- a/codalab/apps/web/views.py
+++ b/codalab/apps/web/views.py
@@ -1319,6 +1319,11 @@ class MyCompetitionSubmissionsPage(LoginRequiredMixin, TemplateView):
             raise Http404()
 
         context['selected_phase'] = selected_phase
+
+        # Get user status to give right to rerun all phases or not 
+        if (self.request.user.is_superuser or self.request.user.is_staff):
+            context['is_superuser_or_staff'] = True
+
         return context
 
 


### PR DESCRIPTION
Feature requested from the following issue : #2948

The buttom is disabled for competition admins or owners, unless they have superuser/staff access

![image](https://user-images.githubusercontent.com/83833966/122114691-9412bb00-cdf1-11eb-8b90-203daba28b43.png)
![image](https://user-images.githubusercontent.com/83833966/122114636-83624500-cdf1-11eb-986f-aef1517685e1.png)

Note that the UI is not as the one in the original issue since it seems to have changed following commit debc04349ff7a3942edbf2d7dd8fbfe1f8141170


The change required adding a flag to the competition submissions page view on the user's access level, communicating it to the js script, and having the Vuetify button put conditional to its value.


# Checklist for hand testing
- [x] competition admin/owner with superuser and/or staff access can see and click to the button
- [x] competition admin/owner without superuser and/or staff access can't see the button
- [x] button is still re-launching every submissions


# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] Ready to merge
