### PR TITLE
submissions page filter to check for equal phase's phasenumber and su…

### DIFF
--- a/codalab/apps/web/templates/web/my/submissions.html
+++ b/codalab/apps/web/templates/web/my/submissions.html
@@ -472,7 +472,7 @@
                         filtered_submissions() {
                             return this.submissions.filter(s => {
                                 if (this.phase) {
-                                    return this.phase.id !== s.phase.id
+                                    return this.phase.phasenumber == s.phase_number
                                 } else {
                                     return true
                                 }


### PR DESCRIPTION
# A brief description of the purpose of the changes contained in this PR.  
 Issues on the matter : https://github.com/codalab/codalab-competitions/issues/2970 
 
Small fix so that the filtering on phases works for the submission list in the competition admin's submission page.

Before the fix, the filter would have no impact, since it was trying to compare non-existing attributes of phases and submissions
In this example prior to the fix, the submission's phase is not in line with the one selected in the filter
![image](https://user-images.githubusercontent.com/83833966/126400248-18411924-1e9d-41a1-8839-ad6e6eee8140.png)  

For the same example after the fix, now the submission is excluded from the list
![image](https://user-images.githubusercontent.com/83833966/126400300-fb503493-bb19-4e4c-82e2-5badfa06a27e.png)


# A checklist for hand testing
- [x] Leaving no selection shows all submissions
- [x] Selecting a phase filters out all submissions not for this phase
- [x] Having submissions for different phases doesn't impact the behavior

# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] Ready to merge
