### PR TITLE
py3 Submissions page filter fix

### DIFF
--- a/codalab/apps/web/templates/web/my/submissions.html
+++ b/codalab/apps/web/templates/web/my/submissions.html
@@ -180,7 +180,7 @@
                                     Select a phase to view details & run actions against it<br>
                                 </span>
 
-                                <v-btn
+                                <v-btn v-if="is_superuser_or_staff" 
                                         :disabled="!phase"
                                         @click="re_run_all_submissions"
                                 >
@@ -433,6 +433,7 @@
     <script>
         $(document).ready(function () {
             var COMPETITION_ID = {{ competition.id }}
+            var IS_SUPERUSER_OR_STAFF = {{is_superuser_or_staff|yesno:"true,false" }}
                 {#var PHASE_ID = {{ selected_phase.id }}#}
                 new Vue({
                     el: '#app',
@@ -463,7 +464,8 @@
                             submissions: [],
                             phase: null,
                             phases: [],
-                            loading: true
+                            loading: true,
+                            is_superuser_or_staff: IS_SUPERUSER_OR_STAFF
                         }
                     },
                     computed: {

--- a/codalab/apps/web/templates/web/my/submissions.html
+++ b/codalab/apps/web/templates/web/my/submissions.html
@@ -472,7 +472,7 @@
                         filtered_submissions() {
                             return this.submissions.filter(s => {
                                 if (this.phase) {
-                                    return this.phase.id !== s.phase.id
+                                    return this.phase.phasenumber == s.phase_number
                                 } else {
                                     return true
                                 }

--- a/codalab/apps/web/views.py
+++ b/codalab/apps/web/views.py
@@ -1425,6 +1425,11 @@ class MyCompetitionSubmissionsPage(LoginRequiredMixin, TemplateView):
             context['is_admin_or_owner'] = True
 
         context['selected_phase'] = selected_phase
+
+        # Get user status to give right to rerun all phases or not 
+        if (self.request.user.is_superuser or self.request.user.is_staff):
+            context['is_superuser_or_staff'] = True
+
         return context
 
 


### PR DESCRIPTION
this is the py3 version of this PR : https://github.com/codalab/codalab-competitions/pull/2972

# A brief description of the purpose of the changes contained in this PR.  
 Issues on the matter : https://github.com/codalab/codalab-competitions/issues/2970 
 
Small fix so that the filtering on phases works for the submission list in the competition admin's submission page.

Before the fix, the filter would have no impact, since it was trying to compare non-existing attributes of phases and submissions
In this example prior to the fix, the submission's phase is not in line with the one selected in the filter
![image](https://user-images.githubusercontent.com/83833966/126400248-18411924-1e9d-41a1-8839-ad6e6eee8140.png)  

For the same example after the fix, now the submission is excluded from the list
![image](https://user-images.githubusercontent.com/83833966/126400300-fb503493-bb19-4e4c-82e2-5badfa06a27e.png)


# A checklist for hand testing
- [ ] Leaving no selection shows all submissions
- [ ] Selecting a phase filters out all submissions not for this phase
- [ ] Having submissions for different phases doesn't impact the behavior

# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [ ] Code review by reviewer
- [ ] Hand tested by reviewer
- [ ] Ready to merge
