### PR TITLE
realigning table by adding missing td in row template

### DIFF
--- a/codalab/apps/web/static/js/Competition.js
+++ b/codalab/apps/web/static/js/Competition.js
@@ -388,7 +388,7 @@ var Competition;
                         return s;
                     };
                     var dt = new Date(response.submitted_at);
-                    var d = ('0' + (dt.getMonth() + 1).toString()).slice(-2) + '/' + dt.getDate().toString() + '/' + dt.getFullYear();
+                    var d = ('0' + (dt.getMonth() + 1).toString()).slice(-2) + '/' + dt.getDate().toString().padStart(2, "0") + '/' + dt.getFullYear();
                     var h = ('0' + dt.getHours().toString()).slice(-2);
                     var m = fmt(dt.getMinutes());
                     var s = fmt(dt.getSeconds());

--- a/codalab/apps/web/templates/web/common/_submission_details_template.html
+++ b/codalab/apps/web/templates/web/common/_submission_details_template.html
@@ -62,6 +62,7 @@
                 <td></td>
                 <td></td>
                 <td></td>
+                <td></td>
                 <td class="statusName"></td>
                 <td class="status not_submitted"></td>
                 <td><span class="glyphicon glyphicon-plus"></span></td>


### PR DESCRIPTION
# A brief description of the purpose of the changes contained in this PR.
Fixing bug where the new row in the user's submission table for a submission just added was not correctly aligned with the rest of the table  

# Known issues to be addressed in a separate PR
In https://github.com/codalab/codalab-competitions/issues/2959, merged issues https://github.com/codalab/codalab-competitions/issues/2860 and https://github.com/codalab/codalab-competitions/issues/2862  
  
Also fixed the date format that was not identical to the other rows


# A checklist for hand testing
- [x] Submit a new submission and verify that the table is intact
- [x] Verify that the reresh buttons now appears with a new submission

# Misc. comments
There seemed to be a missing row in the template. Probably a column added to the table after it was deemed migrated to py3.


# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] Ready to merge
