### PR TITLE
testing the existence of a file in storage when accessing its size

### DIFF
--- a/codalab/apps/web/utils.py
+++ b/codalab/apps/web/utils.py
@@ -1,4 +1,5 @@
 import logging
+import traceback
 import os
 import re
 import requests
@@ -255,6 +256,8 @@ def get_size_from_summary(bucket_name, key):
         else:
             # Something else has gone wrong.
             raise
+    except Exception as e:
+        logger.error(traceback.format_exc())
     return size
 
 def delete_key_from_storage(obj, attr, aws_attr=None, s3direct=False, use_boto_method=True):

--- a/codalab/apps/web/utils.py
+++ b/codalab/apps/web/utils.py
@@ -255,7 +255,7 @@ def get_size_from_summary(bucket_name, key):
             logger.error("File was not found in storage. File: {0}; Storage: {1}".format(bucket_name, key))
         else:
             # Something else has gone wrong.
-            raise
+            logger.error(traceback.format_exc())
     except Exception as e:
         logger.error(traceback.format_exc())
     return size

--- a/codalab/apps/web/utils.py
+++ b/codalab/apps/web/utils.py
@@ -3,6 +3,7 @@ import os
 import re
 import requests
 import boto3
+from botocore.exceptions import ClientError
 
 from django.conf import settings
 from django.core.files.storage import get_storage_class
@@ -215,15 +216,13 @@ def get_submission_size(submission):
 
 def get_filefield_size(obj, attr, aws_attr=None, s3direct=False):
     size = None
+    attr_obj = getattr(obj, aws_attr) if aws_attr and s3direct else getattr(obj, attr)
     if settings.USE_AWS and s3direct and aws_attr:
         attr_obj = getattr(obj, aws_attr)
-        bucket = BundleStorage.bucket
         # S3DirectFields are stored as text fields with the full url to the key.
         if attr_obj and attr_obj != '':
             key = s3_key_from_url(attr_obj)
-            obj_summary = s3.ObjectSummary(bucket.name, key)
-            if obj_summary:
-                size = obj_summary.size
+            get_size_from_summary(BundleStorage.bucket.name, key)
     else:
         attr_obj = getattr(obj, attr)
         if attr_obj.name and attr_obj.name != '':
@@ -238,11 +237,25 @@ def get_filefield_size(obj, attr, aws_attr=None, s3direct=False):
                 logger.error(e)
                 # If we hit an exception this way, and we're using S3, try the other method.
                 if settings.USE_AWS:
-                    obj_summary = s3.ObjectSummary(attr_obj.storage.bucket.name, attr_obj.name)
-                    if obj_summary:
-                        size = obj_summary.size
+                    size = get_size_from_summary(attr_obj.storage.bucket.name, attr_obj.name)
     # Always make sure we return at least 0
     return size or 0
+
+def get_size_from_summary(bucket_name, key):
+    size = None
+    # Test if file exists, since it's an observed bug that the object exists but no file is present in the storage
+    try:
+        obj_summary = s3.ObjectSummary(bucket_name, key)
+        if obj_summary:
+            size = obj_summary.size
+    except ClientError as e:
+        if e.response['Error']['Code'] == "404":
+            # The object does not exist.
+            logger.error("File was not found in storage. File: {0}; Storage: {1}".format(bucket_name, key))
+        else:
+            # Something else has gone wrong.
+            raise
+    return size
 
 def delete_key_from_storage(obj, attr, aws_attr=None, s3direct=False, use_boto_method=True):
     """Helper function to do checks and delete a key from storage. Key is FileField.name"""


### PR DESCRIPTION
# @ mention of reviewers
@Tthomas63  I would like your advice on this one. 

# A brief description of the purpose of the changes contained in this PR.
In https://github.com/codalab/codalab-competitions/issues/3034, a user experienced failures of some submission size requests, which broke the all submissions views and the user's submission view. After investigating, it turns out that a submission has an object and a file related to it, but it is nowhere to be found on the storage, therefor crashing when requesting its size in the size computation.


# Known issues to be addressed in a separate PR
We need to figure out how such submission was created and why did it fail to be properly uploaded to the storage.


# A checklist for hand testing
- [x] create a new submission
- [x] alter s3 key of submission so that it looks for an non-existing file
- [x] see that the submission view loads still
- [x] observe log of error


# Misc. comments
I'm not sure if there are security issues with the display of a bucket name in logs?  
Also if you have any idea on how to figure out how this happened let me know


# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] Ready to merge
