### PR TITLE
default max submission size of 300mb upon phase form initialisation

### DIFF
--- a/codalab/apps/web/models.py
+++ b/codalab/apps/web/models.py
@@ -891,7 +891,7 @@ class CompetitionPhase(models.Model):
     color = models.CharField(max_length=24, choices=COLOR_CHOICES, blank=True, null=True)
 
     max_submission_size = models.PositiveIntegerField(
-        default=0,
+        default=300,
         validators=[
             MaxValueValidator(10000),
             MinValueValidator(0)


### PR DESCRIPTION
# A brief description of the purpose of the changes contained in this PR.
Changing default max submission size to 300 megabytes upon phase creation as discussed, to mitigate storage usage.


# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] Ready to merge
