### PR TITLE
Fit the width of the front page message text area to the page by adding a css rule in a new file

### DIFF
--- a/codalab/apps/customizer/static/customizer/customizer.css
+++ b/codalab/apps/customizer/static/customizer/customizer.css
@@ -1,0 +1,3 @@
+#id_front_page_message {
+  width: 100%;
+}

--- a/codalab/apps/customizer/templates/customizer/index.html
+++ b/codalab/apps/customizer/templates/customizer/index.html
@@ -1,8 +1,12 @@
 {% extends "base.html" %}
-
+{% load staticfiles %}
 
 {% block head_title %}Customize Codalab{% endblock %}
 {% block page_title %}Customize Codalab{% endblock page_title %}
+
+{% block extra_scripts %}
+    <link rel="stylesheet" href="{% static 'customizer/customizer.css' %}">
+{% endblock extra_scripts %}
 
 {% block content %}
     <div class="panel-body">


### PR DESCRIPTION
# A brief description of the purpose of the changes contained in this PR.

To improve the user experience, the width of the 'Front page message' TextField needs to be increase.

# Changes
Used a css rule on the id to make the TextFiled used 100% of the remaining width space in the column

Before:
![image](https://user-images.githubusercontent.com/15732780/153283932-98909a95-2637-4afd-8e97-21373d651152.png)

After:
![image](https://user-images.githubusercontent.com/15732780/153284492-dd7dcd61-06a3-46d9-8060-5355940be789.png)

# Misc. comments

The related issue was first #3021 
But it has been moved into a bigger issue: #1920 

# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] Ready to merge
