### PR TITLE
update code/data that preloads site domain to database

### DIFF
--- a/codalab/apps/web/fixtures/initialize_site.json
+++ b/codalab/apps/web/fixtures/initialize_site.json
@@ -1,0 +1,1 @@
+[{"model": "sites.site", "pk": 1, "fields": {"domain": "example.com", "name": "example.com"}}]

--- a/codalab/apps/web/fixtures/initialize_site.json
+++ b/codalab/apps/web/fixtures/initialize_site.json
@@ -1,1 +1,1 @@
-[{"model": "sites.site", "pk": 1, "fields": {"domain": "example.com", "name": "example.com"}}]
+[{"model": "sites.site", "pk": 1, "fields": {"domain": "localhost", "name": "localhost"}}]

--- a/codalab/scripts/initialize_from_fixture.py
+++ b/codalab/scripts/initialize_from_fixture.py
@@ -2,13 +2,9 @@ import os, json
 
 with open("apps/web/fixtures/initialize_site.json",'r') as initial_site_json:
     json_data = json.loads(initial_site_json.read())
-    json_data[0]['fields']['domain'] = os.environ['CODALAB_SITE_DOMAIN']
-    json_data[0]['fields']['name'] = 'CODALAB_SITE_DOMAIN'
+    json_data[0]['fields']['domain'] = os.environ.get('CODALAB_SITE_DOMAIN', 'localhost')
+    json_data[0]['fields']['name'] = os.environ.get('CODALAB_SITE_DOMAIN', 'localhost')
 
 with open("apps/web/fixtures/initialize_site.json",'w') as post_site_json:
     post_site_json.write(json.dumps(json_data))
     
-
-
-
-

--- a/codalab/scripts/initialize_from_fixture.py
+++ b/codalab/scripts/initialize_from_fixture.py
@@ -1,0 +1,14 @@
+import os, json
+
+with open("apps/web/fixtures/initialize_site.json",'r') as initial_site_json:
+    json_data = json.loads(initial_site_json.read())
+    json_data[0]['fields']['domain'] = os.environ['CODALAB_SITE_DOMAIN']
+    json_data[0]['fields']['name'] = 'CODALAB_SITE_DOMAIN'
+
+with open("apps/web/fixtures/initialize_site.json",'w') as post_site_json:
+    post_site_json.write(json.dumps(json_data))
+    
+
+
+
+

--- a/docker/run_django.sh
+++ b/docker/run_django.sh
@@ -21,10 +21,13 @@ python manage.py collectstatic --noinput
 
 python manage.py migrate
 
-# For Django 1.7 we cannot run this here. Now using fixtures with loaddata, keeping this here for history
-# Insert initial data into the database
+# Inject user data from .env (site domain) into initialize_site.json
+python scripts/initialize_from_fixture.py
 
-python manage.py loaddata initial_data.json initial_team_data.json
+# For Django 1.7 we cannot run this here. Now using fixtures with loaddata, keeping this here for history
+# Insert initial data into the database (user data and database defaults)
+
+python manage.py loaddata initial_data.json initialize_site.json initial_team_data.json
 
 # start development server on public ip interface, on port 8000
 PYTHONUNBUFFERED=TRUE gunicorn codalab.wsgi \


### PR DESCRIPTION
Below is my  .env (skip to get to bug and PR discussion):
```
# ----------------------------------------------------------------------------
# Submission processing
# ----------------------------------------------------------------------------
SUBMISSION_TEMP_DIR=/tmp/codalab

# ----------------------------------------------------------------------------
# Storage
# ----------------------------------------------------------------------------

# Uncomment to use Azure
DEFAULT_FILE_STORAGE=codalab.azure_storage.AzureStorage
AZURE_ACCOUNT_NAME=*************************
AZURE_ACCOUNT_KEY=*************************
AZURE_CONTAINER=public
# Only set these if bundle storage key is different from normal account keys
# BUNDLE_AZURE_ACCOUNT_NAME=
# BUNDLE_AZURE_ACCOUNT_KEY=
BUNDLE_AZURE_CONTAINER=bundles

# ----------------------------------------------------------------------------
# Database
# ----------------------------------------------------------------------------

# Used engine (mysql, postgresql, sqlite3, memory)
DB_ENGINE=postgresql

# Connection parameters
DB_HOST=postgres
DB_PORT=5432
DB_NAME=codalab_website
DB_USER=root
DB_PASSWORD=password

# Path where DB files will be mapped
DB_DATA_PATH=./var/data/postgres


# ----------------------------------------------------------------------------
# Caching
# ----------------------------------------------------------------------------
MEMCACHED_PORT=11211


# ----------------------------------------------------------------------------
# RabbitMQ and management
# ----------------------------------------------------------------------------
RABBITMQ_DEFAULT_USER=guest
RABBITMQ_DEFAULT_PASS=guest
BROKER_URL=pyamqp://guest:guest@rabbit:5671//
BROKER_USE_SSL=True
RABBITMQ_PORT=5671
RABBITMQ_MANAGEMENT_PORT=15671

#BROKER_URL=pyamqp://$RABBITMQ_DEFAULT_USER:$RABBITMQ_DEFAULT_PASS@rabbit:5672//
#BROKER_USE_SSL=True
RABBITMQ_HOST=rabbit
#RABBITMQ_PORT=5672
#RABBITMQ_MANAGEMENT_PORT=15672
FLOWER_BASIC_AUTH=root:password
FLOWER_PORT=5555


# ----------------------------------------------------------------------------
# Django/nginx
# ----------------------------------------------------------------------------
DJANGO_SECRET_KEY=change-me-to-a-secret
DJANGO_PORT=8000
DEBUG=True
IS_DEV=True
NGINX_PORT=80

SSL_PORT=443
SSL_CERTIFICATE=/app/certs/fullchain.pem
SSL_CERTIFICATE_KEY=/app/certs/privkey.pem
# Allowed hosts separated by space
SSL_ALLOWED_HOSTS=codalab-python3-test.eastus.cloudapp.azure.com

# Turn on and off "User Switching Middleware" which allows you to change
# users to see any bugs or issues they may be having
#
# ** WARNING ** could be used by malicious user to see other user's private 
# data
USER_SWITCH_MIDDLEWARE=True

# Set this to your actual domain, like example.com
CODALAB_SITE_DOMAIN=codalab-python3-test.eastus.cloudapp.azure.com

# How many site workers (submission result processors)?
WEB_CONCURRENCY=2

# ----------------------------------------------------------------------------
# Logging
# ----------------------------------------------------------------------------
# Make sure LOGGING_DIR doesn't end with a slash
LOGGING_DIR=./var/logs
DJANGO_LOG_LEVEL=debug


# ----------------------------------------------------------------------------
# ChaHub
# ----------------------------------------------------------------------------
# Be sure to include trailing slash on URL
#CHAHUB_API_URL=https://chahub.org/api/v1/
#CHAHUB_API_KEY=some-secret-key
#SOCIAL_AUTH_CHAHUB_BASE_URL=https://chahub.org

EMAIL_BACKEND=django.core.mail.backends.smtp.EmailBackend
EMAIL_HOST=smtp.sendgrid.net
EMAIL_HOST_USER=apikey
EMAIL_HOST_PASSWORD=*********************
EMAIL_PORT=587
EMAIL_USE_TLS=True
DEFAULT_FROM_EMAIL=MedICI <kalpathy@mgh.harvard.edu>
SERVER_EMAIL=kalpathy@mgh.harvard.edu
```




> Start Discussion
--------------------------------------------------------------------------------------------------------------------------


# A brief description of the purpose of the changes contained in this PR.
Upon initial deploy, the django container has run_django.sh executed. This creates database migrations and pre-loads the database with a fixture of json located at *codalab-competitions/codalab/apps/web/fixtures/initial_data.json*. This fixture does nothing to the *sites.site* table which holds the site domain. The default for this table is *example.com* (which [django sites](https://docs.djangoproject.com/en/4.0/ref/contrib/sites/) sets). 

If this is not updated to reflect the real domain, then when CodaLab sends confirmation emails to the applying users, the confirmation link is formatted as "https://example.com/accounts/confirm-email/MQ:1n9XOv:ehbVpB2B7La1QjcByTDZRHuAV0Y/". 

So instead of manually updating this after deploy, this PR aims to automate this action by adding entries in initialize_site.json so that run_django.sh can overwrite them right before the json is loaded into the DB. The values being referenced are environment variable CODALAB_SITE_DOMAIN and it's value. 

Ex (prior to overwriting):
```
{"model":"sites.site","pk":1,"fields":{"domain":"example.com","name":"example.com"}}
```

Ex (after overwriting):
```
{"model":"sites.site","pk":1,"fields":{"domain":"codalab-python3-test.eastus.cloudapp.azure.com","name":"CODALAB_SITE_DOMAIN"}}
```

# A checklist for hand testing
- Set these .env variables before attempting
  * CODALAB_SITE_DOMAIN
  * SSL_ALLOWED_HOSTS
  * BROKER_URL=pyamqp://guest:guest@rabbit:5671//
  * BROKER_USE_SSL=True
  * RABBITMQ_PORT=5671
  * RABBITMQ_MANAGEMENT_PORT=15671
  * EMAIL_BACKEND=django.core.mail.backends.smtp.EmailBackend
  * EMAIL_HOST=smtp.sendgrid.net
  * EMAIL_HOST_USER=apikey
  * EMAIL_HOST_PASSWORD=*******
  * EMAIL_PORT=587
  * EMAIL_USE_TLS=True
  * DEFAULT_FROM_EMAIL=<some email>
  * SERVER_EMAIL=<some email>


# Any relevant files for testing
New files:
codalab/apps/web/fixtures/initialize_site.json
codalab/scripts/initialize_from_fixture.py

File Changes:
docker/run_django.sh

Testing:
[1] Clone project
[2] Set .env file with all environment variables, specifically CODALAB_SITE_DOMAIN
[3] Run ```docker-compose up -d```
[4] Create an account by using the "Sign Up" button
[5] Go to your email and find the confirmation email
[6] Check that the below email template that is sent doesn't have "example.com" in the link but rather your CODALAB_SITE_DOMAIN env value.
Example Correct:
```
Hi bbearce,

You have signed up for an CodaLab account on [codalab-python3-test.eastus.cloudapp.azure.com](http://codalab-python3-test.eastus.cloudapp.azure.com/) using this
email address.  To confirm and activate your account, please follow the link
below:
```
Example Incorrect:
```
Hi bbearce,

You have signed up for an CodaLab account on [example.com](http://example.com/) using this
email address.  To confirm and activate your account, please follow the link
below:
```
# Misc. comments
- If you don't use https, then the redirection email "https://example.com/accounts/confirm-email/MQ:1n9XOv:ehbVpB2B7La1QjcByTDZRHuAV0Y/" will try to use https and the site will not be found. I noticed just reloading the page or pressing enter or somehow forcing the url to use http will work. I ended up using [certbot](https://certbot.eff.org/) to make certs and just secured the site for testing.

- in run_django.sh I decided to use node to do the overwriting of initial_data.json. There is a good bash command tool called [jq](https://stedolan.github.io/jq/) that is nice but I thought it would be better to use the tools we already have versus installing more tools in the main django Dockerfile. As it stands the javascript code is written out in run_django.sh instead of being in a file under  codalab-competitions/scripts. I couldn't tell if adding more files to the overall codalab code base was more clutter versus having a file that is run from run_django.sh. I could easily make a script for this called adjust_site_domain.js if that is cleaner. 

# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] Ready to merge
