### PR TITLE
new circleci workflow

### DIFF
--- a/.circleci/circlec_dev_setup.py
+++ b/.circleci/circlec_dev_setup.py
@@ -1,0 +1,18 @@
+from .base import DevBase
+
+
+class Test(DevBase):
+    """This is needed to run circleci, it should be copied to local.py"""
+    ENABLE_COMPETITIONS = True
+    ENABLE_WORKSHEETS = False
+    CACHES = {
+        'default': {
+            'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
+        }
+    }
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.db.backends.sqlite3',
+            'NAME': ':memory:',
+        }
+    }

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,41 @@
+version: 2
+
+test:
+  override:
+    - (cd codalab && py.test)
+
+jobs:
+  build:
+    environment:
+      DJANGO_SETTINGS_MODULE: codalab.settings
+      DJANGO_CONFIGURATION: Dev
+    docker:
+      - image: circleci/python:3.8.3
+    steps:
+      - checkout
+      - restore_cache:
+          key: codalab-{{ .Branch }}-{{ checksum "codalab/requirements/common.txt" }}
+      - run:
+          name: CHOWN Python Library Dirs
+          command: sudo chown -R $(whoami) /usr/local/
+      - run:
+          name: Install Memcached reqs
+          command: sudo apt-get update --allow-releaseinfo-change && sudo apt-get install libmemcached-dev --fix-missing
+      - run:
+          name: PIP Install Requirements
+          command: pip install -r codalab/requirements/common.txt
+      - save_cache:
+          key: codalab-{{ .Branch }}-{{ checksum "codalab/requirements/common.txt" }}
+          paths:
+            - "~/.cache/pip"
+      - run:
+          name: Copy settings
+          command: cp .circleci/circlec_dev_setup.py codalab/codalab/settings/local.py
+      - run:
+          name: Run PyTest
+          environment:
+            DJANGO_SETTINGS_MODULE: "codalab.settings.local"
+            DJANGO_CONFIGURATION: "Test"
+            CHAHUB_API_URL: "http://localhost/test/"
+            CHAHUB_API_KEY: "some-secret-key"
+          command: cd codalab && py.test


### PR DESCRIPTION

# A brief description of the purpose of the changes contained in this PR.
CircleCI has a new format or organization for config yaml files. The new way they intend users to use circleci is by placing the config.yaml (formerly known has circleci.yaml) in a folder at .circleci/ from the root of the project directory.

The change made was

[1] create this folder (.circleci)
[2] copy circleci.yaml into .circleci and rename to config.yaml
[3] copy circle_dev_setup.py into .circelci
[4] change line 33 in config.yaml from:
    - command: cp circlec_dev_setup.py codalab/codalab/settings/local.py
    to
    - command: cp .circleci/circlec_dev_setup.py codalab/codalab/settings/local.py
This allows the circle_dev_setup.py to be found and run from the config.yaml


# Misc comments
This change makes it easier for new users to contribute to codalab-competitions. Users need only fork the repo and make an account on circleci's website and link their fork. All of their future forked branch changes can be checked without accepting their PRs first. This allows codalab-competitions admins to check contributions will not break the main develop branch before accepting them.


# A checklist for hand testing
- Fork repo
- Make account on circleci
- Add this repo under "setup project"
- Manually kick off a "workflow" to test the code. It should pass at this commit hash.



# Checklist
- [X] Code review by me 
- [X] Hand tested by me 
- [X] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] Ready to merge
