### PR TITLE
Filefield sizes as str can't be added to int

### DIFF
--- a/codalab/apps/web/utils.py
+++ b/codalab/apps/web/utils.py
@@ -210,9 +210,16 @@ def get_submission_size(submission):
             'ingestion_program_stdout_file',
             'ingestion_program_stderr_file',
         ]
-        total += get_filefield_size(submission, 'file', aws_attr='s3_file', s3direct=True)
+        filefield_size = get_filefield_size(submission, 'file', aws_attr='s3_file', s3direct=True)
+        if type(filefield_size) == str:
+            filefield_size = int(filefield_size)
+        total += filefield_size
         for file_attr in file_attrs:
-            total += get_filefield_size(submission, file_attr)
+            filefield_size = get_filefield_size(submission, file_attr)
+            print(f"file_attr: {filefield_size} type: {type(filefield_size)}")
+            if type(filefield_size) == str:
+                filefield_size = int(filefield_size)
+            total += filefield_size
     return total
 
 def get_filefield_size(obj, attr, aws_attr=None, s3direct=False):

--- a/codalab/apps/web/utils.py
+++ b/codalab/apps/web/utils.py
@@ -210,16 +210,9 @@ def get_submission_size(submission):
             'ingestion_program_stdout_file',
             'ingestion_program_stderr_file',
         ]
-        filefield_size = get_filefield_size(submission, 'file', aws_attr='s3_file', s3direct=True)
-        if type(filefield_size) == str:
-            filefield_size = int(filefield_size)
-        total += filefield_size
+        total += get_filefield_size(submission, 'file', aws_attr='s3_file', s3direct=True)
         for file_attr in file_attrs:
-            filefield_size = get_filefield_size(submission, file_attr)
-            print(f"file_attr: {filefield_size} type: {type(filefield_size)}")
-            if type(filefield_size) == str:
-                filefield_size = int(filefield_size)
-            total += filefield_size
+            total += get_filefield_size(submission, file_attr)
     return total
 
 def get_filefield_size(obj, attr, aws_attr=None, s3direct=False):
@@ -247,6 +240,8 @@ def get_filefield_size(obj, attr, aws_attr=None, s3direct=False):
                 if settings.USE_AWS:
                     size = get_size_from_summary(attr_obj.storage.bucket.name, attr_obj.name)
     # Always make sure we return at least 0
+    if type(size) == str:
+        size = int(size)
     return size or 0
 
 def get_size_from_summary(bucket_name, key):


### PR DESCRIPTION
# Live Deploy
[https://codalab-python3-test.eastus.cloudapp.azure.com/](https://codalab-python3-test.eastus.cloudapp.azure.com/)

# @ mention of reviewers
@Tthomas63 
@Didayolo 


# A brief description of the purpose of the changes contained in this PR.
In codalab/apps/web/utils.py, exists a function defined roughly as so:
```
get_filefield_size(obj, attr, aws_attr=None, s3direct=False):
...
    return size or 0
```
which I have added this to:
```
    if type(size) == str:
        size = int(size)
```

so that it now reads:
```
get_filefield_size(obj, attr, aws_attr=None, s3direct=False):
...
    if type(size) == str:
        size = int(size)
    
    return size or 0
```

The purpose of this change is fix the error that happens when function get_submission_size(submission) in the same file gets called and uses get_filefield_size().  get_submission_size(submission) has a variable ```total``` (int), that gets updated to the sum of itself and the returned size from get_filefield_size(). ```size``` is getting set to a string and is therefore not able to be added to the int variable total. This code change casts the size variable to int before returning to avoid this issue.


# Known issues to be addressed in a separate PR
None


# A checklist for hand testing
- [x] create a competition
- [x] make a submission


# Any relevant files for testing
Sample Competition:
[yellow_world_competition_bundle.zip](https://github.com/codalab/codalab-competitions/files/8624875/yellow_world_competition_bundle.zip)

Sample Submission:
[yellow_world_sample_submission.zip](https://github.com/codalab/codalab-competitions/files/8624873/yellow_world_sample_submission.zip)


# Misc. comments
Perhaps python3 updates have subtle changes in which values that used to be ints are now strings. There could be a better solution upstream, but this was blocking for me on a fresh deploy.


# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] Ready to merge
