### PR TITLE
forcing submissions page to have distinct results

### DIFF
--- a/codalab/apps/api/views/competition_views.py
+++ b/codalab/apps/api/views/competition_views.py
@@ -715,7 +715,7 @@ class CompetitionSubmissionListViewSet(mixins.ListModelMixin, viewsets.GenericVi
         # Only get submissions for this competition, and only if you're an admin
         competition_id = self.kwargs['competition_id']
         qs = qs.filter(phase__competition_id=competition_id).order_by('-pk')
-        qs = qs.filter(Q(phase__competition__creator=self.request.user) | Q(phase__competition__admins__in=[self.request.user]))
+        qs = qs.filter(Q(phase__competition__creator=self.request.user) | Q(phase__competition__admins__in=[self.request.user])).distinct()
 
         qs = qs.extra(
             select={


### PR DESCRIPTION
# @ mention of reviewers
@Didayolo 


# A brief description of the purpose of the changes contained in this PR.
Submissions page shows duplicate submissions for each user.

# Known issues to be addressed in a separate PR
...


# A checklist for hand testing
- [x] make submission and see that there are only unique ids.


# Any relevant files for testing
[link]('#') to any relevant files (or drag and drop into github)


# Misc. comments
Simple fix


# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] Ready to merge
