### PR TITLE
Detailed Results References Wrong User

### DIFF
--- a/codalab/apps/web/templates/base.html
+++ b/codalab/apps/web/templates/base.html
@@ -239,8 +239,8 @@
         CODAUSER = {
             username: "{{ request.user.username }}",
             user_id: {{ request.user.pk|default:0 }},
-            email: "{{ user.email }}",
-            is_authenticated: {{ user.is_authenticated|yesno:"true,false" }},
+            email: "{{ request.user.email }}",
+            is_authenticated: {{ request.user.is_authenticated|yesno:"true,false" }},
         }
 
         /*

--- a/codalab/apps/web/templates/web/competitions/edit.html
+++ b/codalab/apps/web/templates/web/competitions/edit.html
@@ -46,7 +46,7 @@
                         <div class="field-container">
                             <select multiple id="id_admins" name="admins">
                                 {% for admin in competition.admins.all %}
-                                    <option value="{{ admin.pk }}" selected>{{ admin }}</option>
+                                    <option value="{{ admin.pk }}" selected>{{ admin.username }}</option>
                                 {% endfor %}
                             </select>
                             {{ field.errors }}


### PR DESCRIPTION
### Changes

In base.html reference `request.user` instead of `user` for conflicts when context variable named `user` is passed and overwrites initial variable; Edge case for pre-selected admins to display only username.

# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] Ready to merge
