### PR TITLE
base template link to "/my/" instead of "/my" 

### DIFF
--- a/codalab/apps/web/templates/account/login.html
+++ b/codalab/apps/web/templates/account/login.html
@@ -63,7 +63,7 @@
             <button class="btn btn-primary margin-top" type="submit">{% trans "Sign In" %}</button>
         </form>
         <p>
-        <p><a href="../signup/">Don't have an account? Sign up!</a></p>
+        <p><a href="{% url 'account_signup' %}">Don't have an account? Sign up!</a></p>
         <p><a href="../password/reset/">Forgot your password?</a></p>
         <a href="" onclick="alert('Please wait 5 minutes and attempt logging in again to resend confirmation email.'); return false;">Resend confirmation email</a>
     </div>

--- a/codalab/apps/web/templates/account/login.html
+++ b/codalab/apps/web/templates/account/login.html
@@ -63,7 +63,7 @@
             <button class="btn btn-primary margin-top" type="submit">{% trans "Sign In" %}</button>
         </form>
         <p>
-        <p><a href="../signup">Don't have an account? Sign up!</a></p>
+        <p><a href="../signup/">Don't have an account? Sign up!</a></p>
         <p><a href="../password/reset/">Forgot your password?</a></p>
         <a href="" onclick="alert('Please wait 5 minutes and attempt logging in again to resend confirmation email.'); return false;">Resend confirmation email</a>
     </div>

--- a/codalab/apps/web/templates/base.html
+++ b/codalab/apps/web/templates/base.html
@@ -89,11 +89,11 @@
                           <li class="{% active request '/my/' %}">
                               {% if SINGLE_COMPETITION_VIEW_PK %}
                                   {% if request.user.is_superuser or request.user.is_staff %}
-                                      <a href="/my">My Competitions</a>
+                                      <a href="/my/">My Competitions</a>
                                   {% endif %}
                               {% else %}
                                   {% if user.is_authenticated %}
-                                      <a href="/my">My Competitions</a>
+                                      <a href="/my/">My Competitions</a>
                                   {% else %}
                                       <a href="/competitions/">Search Competitions</a>
                                   {% endif %}


### PR DESCRIPTION
The header has links to `/my`, `/my/settings/`, `/accounts/password/reset/`, and `/accounts/logout/`. The first does not end in a `/` so when the user clicks on it, it goes through a 301 redirect to `/my/`. The others all end up in `/` but are generated by `url` in the template.

I'm not sure where that redirect is happening but I'm codalab setting up behind a proxy and the redirects breaks. This is probably an issue with my proxy configuration but using `/my/` fixes the issue while making it consistent with the other links in the header.