### PR TITLE
.env_sample: remove mention of USER_SWITCH_MIDDLEWARE unused since 33f29205e4e2e2d78

### DIFF
--- a/.env_sample
+++ b/.env_sample
@@ -113,13 +113,6 @@ SSL_PORT=443
 # Allowed hosts separated by space
 SSL_ALLOWED_HOSTS=
 
-# Turn on and off "User Switching Middleware" which allows you to change
-# users to see any bugs or issues they may be having
-#
-# ** WARNING ** could be used by malicious user to see other user's private 
-# data
-USER_SWITCH_MIDDLEWARE=True
-
 # Set this to your actual domain, like example.com
 CODALAB_SITE_DOMAIN=localhost
 


### PR DESCRIPTION
The environment variable `USER_SWITCH_MIDDLEWARE` seems to no longer have any effect for over 4 years (since 33f29205e4e2e2d78 when `userswitch.middleware.UserSwitchMiddleware` was replaced with `django_switchuser.middleware.SuStateMiddleware`) but it's mentioned on `.env_sample`. This commit removes it.