### PR TITLE
Add GOOGLE_ANALYTICS setting (closes #3207)

### DIFF
--- a/.env_production_sample
+++ b/.env_production_sample
@@ -120,6 +120,9 @@ CODALAB_SITE_DOMAIN=localhost
 # How many site workers (submission result processors)?
 WEB_CONCURRENCY=16
 
+# Google Analytics code (leave empty to disable Google's user tracking)
+GOOGLE_ANALYTICS=
+
 
 # ----------------------------------------------------------------------------
 # ChaHub

--- a/.env_sample
+++ b/.env_sample
@@ -119,6 +119,9 @@ CODALAB_SITE_DOMAIN=localhost
 # How many site workers (submission result processors)?
 WEB_CONCURRENCY=2
 
+# Google Analytics code (leave empty to disable Google's user tracking)
+GOOGLE_ANALYTICS=
+
 # ----------------------------------------------------------------------------
 # Logging
 # ----------------------------------------------------------------------------

--- a/codalab/apps/web/templates/base.html
+++ b/codalab/apps/web/templates/base.html
@@ -24,7 +24,6 @@
         <link rel="stylesheet" href="{% static "css/jquery.dataTables.css" %}">
         <link rel="stylesheet" href="{% static "css/jquery-editable.css" %}">
         <link rel="stylesheet" href="{% static "js/vendor/select2/select2.css" %}" />
-        <link rel="stylesheet" href="{% static "css/jquery-eu-cookie-law-popup.css" %}">
         {% if compile_less %}
             <link rel="stylesheet" type="text/css" href="{% static "css/imports.css" %}">
         {% else %}
@@ -38,7 +37,6 @@
         <!--[if lt IE 9]>
             <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
         <![endif]-->
-        <script src="{% static "js/vendor/jquery-eu-cookie-law-popup.js" %}"></script>
     {% endblock css %}
 
     {% block extra_headers %}
@@ -222,16 +220,6 @@
     </div>
 
     <script type="text/javascript">
-
-    //GOOGLE ANALYTICS SNIPPET
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-              (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-              })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-
-              ga('create', 'UA-42847758-2', 'auto');
-              ga('send', 'pageview');
-
     {% block js %}
         Competition.initialize();
 
@@ -263,6 +251,21 @@
 
     {% analytical_body_top %}
     {% analytical_body_bottom %}
-    <div class="eupopup eupopup-top"></div>
+
+    {% if GOOGLE_ANALYTICS %}
+      <link rel="stylesheet" href="{% static "css/jquery-eu-cookie-law-popup.css" %}">
+      <script src="{% static "js/vendor/jquery-eu-cookie-law-popup.js" %}"></script>
+      <div class="eupopup eupopup-top"></div>
+      <script type="text/javascript">
+        //GOOGLE ANALYTICS SNIPPET
+        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+              (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+              })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+              ga('create', '{{ GOOGLE_ANALYTICS }}', 'auto');
+              ga('send', 'pageview');
+      </script>
+    {% endif %}
 </body>
 </html>

--- a/codalab/codalab/context_processors.py
+++ b/codalab/codalab/context_processors.py
@@ -22,4 +22,5 @@ def common_settings(request):
         'USE_AWS': codalab_settings.USE_AWS,
         'CODALAB_SITE_DOMAIN': codalab_settings.CODALAB_SITE_DOMAIN,
         'USE_MAILCHIMP': bool(settings.MAILCHIMP_API_KEY),
+        'GOOGLE_ANALYTICS': codalab_settings.GOOGLE_ANALYTICS,
     }

--- a/codalab/codalab/settings/base.py
+++ b/codalab/codalab/settings/base.py
@@ -273,8 +273,8 @@ class Base(Configuration):
     ACCOUNT_SIGNUP_FORM_CLASS = 'apps.authenz.forms.CodalabSignupForm'
     ACCOUNT_LOGOUT_ON_GET = True
 
-    # Django Analytical configuration
-    # GOOGLE_ANALYTICS_PROPERTY_ID = 'UA-42847758-2'
+    # Privacy (leave empty to not track visitors with Google)
+    GOOGLE_ANALYTICS = os.environ.get('GOOGLE_ANALYTICS', '')
 
     # Compress Configuration
     COMPRESS_PRECOMPILERS = [


### PR DESCRIPTION
As discussed on #3207, the same Google Analytics code is used in all instances and there isn't a way to make it optional. This PR adds a new option so that people can specify whatever GA code they have or even leave it empty to not do any tracking.

I have moved all the related stuff to a single block in `<body>` only to avoid having multiple `{% if GOOGLE_ANALYTICS %}` in different places (which one day can cause problems if one place changes and the other's don't). This means moving `<link>` and `<script>` into `<body>` which is OK with HTML5.