### PR TITLE
codalab/apps/web/templates/base.html: remove CODAUSER unused since 9c9939e1cdfa

### DIFF
--- a/codalab/apps/web/templates/base.html
+++ b/codalab/apps/web/templates/base.html
@@ -234,15 +234,7 @@
 
     {% block js %}
         Competition.initialize();
-
     {% endblock js %}
-        CODAUSER = {
-            username: "{{ request.user.username }}",
-            user_id: {{ request.user.pk|default:0 }},
-            email: "{{ request.user.email }}",
-            is_authenticated: {{ request.user.is_authenticated|yesno:"true,false" }},
-        }
-
         /*
          * If we want to do huge maintenance again, can use this warning!
          *


### PR DESCRIPTION
Each page has injected a `CODAUSER` variable with the username, user id, and email. This is leftovers from some other code that is no longer around and can be removed.