### PR TITLE
Feature/storage/admin competitions manager additional features

### DIFF
--- a/codalab/apps/api/routers.py
+++ b/codalab/apps/api/routers.py
@@ -1,5 +1,6 @@
 from apps.api.views import competition_views as views
 from apps.api.views import storage_views as storage_views
+from apps.api.views import admin_views as admin_views
 from django.conf.urls import url
 from rest_framework import routers
 
@@ -40,4 +41,7 @@ urlpatterns += (
     # Storage Analytics
     url(r'^storage/analytics', storage_views.GetExistingStorageAnalytics.as_view(), name="existing_storage_analytics"),
     url(r'^storage/usage-history', storage_views.GetStorageUsageHistory.as_view(), name="storage_usage_history"),
+    # Admin
+    url(r'^admin/competitions/list', admin_views.GetCompetitions.as_view(), name="competitions"),
+    url(r'^admin/competitions/update', admin_views.UpdateCompetitions.as_view(), name="update_competitions"),
 )

--- a/codalab/apps/api/routers.py
+++ b/codalab/apps/api/routers.py
@@ -44,5 +44,6 @@ urlpatterns += (
     # Admin
     url(r'^admin/competitions/list', admin_views.GetCompetitions.as_view(), name="competitions"),
     url(r'^admin/competitions/update', admin_views.UpdateCompetitions.as_view(), name="update_competitions"),
-    url(r'^admin/competition/(?P<competition_id>\d+)/apply_upper_bound_limit', admin_views.ApplyUpperBoundLimit.as_view(), name="apply_upper_bound_limit")
+    url(r'^admin/competition/(?P<competition_id>\d+)/apply_upper_bound_limit', admin_views.ApplyUpperBoundLimit.as_view(), name="apply_upper_bound_limit"),
+    url(r'^admin/competitions/default_upper_bound_limit', admin_views.GetDefaultUpperBoundLimit.as_view(), name="get_default_upper_bound_limit")
 )

--- a/codalab/apps/api/routers.py
+++ b/codalab/apps/api/routers.py
@@ -44,4 +44,5 @@ urlpatterns += (
     # Admin
     url(r'^admin/competitions/list', admin_views.GetCompetitions.as_view(), name="competitions"),
     url(r'^admin/competitions/update', admin_views.UpdateCompetitions.as_view(), name="update_competitions"),
+    url(r'^admin/competition/(?P<competition_id>\d+)/apply_upper_bound_limit', admin_views.ApplyUpperBoundLimit.as_view(), name="apply_upper_bound_limit")
 )

--- a/codalab/apps/api/views/admin_views.py
+++ b/codalab/apps/api/views/admin_views.py
@@ -26,7 +26,7 @@ class GetCompetitions(views.APIView):
             competitions.append({
                 'id': competition.id,
                 'title': competition.title,
-                'creator': competition.creator.username,
+                'creator': competition.creator.username + " (" + competition.creator.email + ")",
                 'start_date': competition.start_date,
                 'end_date': competition.end_date,
                 'upper_bound_max_submission_size': competition.upper_bound_max_submission_size

--- a/codalab/apps/api/views/admin_views.py
+++ b/codalab/apps/api/views/admin_views.py
@@ -1,0 +1,83 @@
+from rest_framework import (permissions, status, views)
+from rest_framework.decorators import permission_classes
+from rest_framework.exceptions import PermissionDenied
+from rest_framework.response import Response
+
+import logging
+
+from django.db import transaction
+
+from apps.web.models import Competition
+
+logger = logging.getLogger(__name__)
+
+
+@permission_classes((permissions.IsAuthenticated,))
+class GetCompetitions(views.APIView):
+    """
+    Gets the competitions
+    """
+    def get(self, request, *args, **kwargs):
+        if not self.request.user.is_staff:
+            raise PermissionDenied(detail="Admin only")
+
+        competitions = []
+        for competition in list(Competition.objects.order_by('id').all()):
+            competitions.append({
+                'id': competition.id,
+                'title': competition.title,
+                'creator': competition.creator.username,
+                'start_date': competition.start_date,
+                'end_date': competition.end_date,
+                'upper_bound_max_submission_size': competition.upper_bound_max_submission_size
+            })
+
+        return Response(competitions, status=status.HTTP_200_OK)
+
+@permission_classes((permissions.IsAuthenticated,))
+class UpdateCompetitions(views.APIView):
+    """
+    Update competitions in batch
+    body template:
+    {
+        competitions: [
+            {
+                id: 0,
+                <attribute>: <value>
+            }
+        ]
+    }
+    """
+    def post(self, request, *args, **kwargs):
+        if not self.request.user.is_staff:
+            raise PermissionDenied(detail="Admin only")
+        
+        competitions_to_update = request.data['competitions']
+        if not competitions_to_update:
+            return Response("No competitions to update", status=status.HTTP_204_NO_CONTENT)
+
+        with transaction.atomic():
+            for competition in competitions_to_update:
+                try:
+                    competition_in_db = Competition.objects.select_for_update().get(pk=competition['id'])
+                    for attribute, value in competition.items():
+                        if attribute != 'id':
+                            logger.debug("Updating competition %d", competition_in_db.id)
+                            setattr(competition_in_db, attribute, value)
+                    competition_in_db.save()
+                except Competition.DoesNotExist:
+                    return Response(status=status.HTTP_404_NOT_FOUND)
+
+        ids = [comp['id'] for comp in competitions_to_update]
+        competitions_updated = []
+        for comp_id, competition in Competition.objects.in_bulk(ids).items():
+            competitions_updated.append({
+                'id': comp_id,
+                'title': competition.title,
+                'creator': competition.creator.username,
+                'start_date': competition.start_date,
+                'end_date': competition.end_date,
+                'upper_bound_max_submission_size': competition.upper_bound_max_submission_size
+            })
+
+        return Response(competitions_updated, status=status.HTTP_200_OK)

--- a/codalab/apps/api/views/admin_views.py
+++ b/codalab/apps/api/views/admin_views.py
@@ -6,6 +6,7 @@ from rest_framework.response import Response
 import logging
 
 from django.db import transaction
+from django.conf import settings
 
 from apps.web.models import Competition, CompetitionPhase
 
@@ -121,3 +122,17 @@ class ApplyUpperBoundLimit(views.APIView):
             'max_submission_sizes': [phase.max_submission_size for phase in competition_updated_in_db.phases.all().order_by('start_date')]
         }
         return Response(competition_updated, status=status.HTTP_200_OK)
+
+
+@permission_classes((permissions.IsAuthenticated,))
+class GetDefaultUpperBoundLimit(views.APIView):
+    """
+    Gets the default upper bound max submission size
+    """
+    def get(self, request, *args, **kwargs):
+        if not self.request.user.is_staff:
+            raise PermissionDenied(detail="Admin only")
+
+        default_upper_bound_max_submission_size = settings.DEFAULT_UPPER_BOUND_MAX_SUBMISSION_SIZE_MB
+
+        return Response(default_upper_bound_max_submission_size, status=status.HTTP_200_OK)

--- a/codalab/apps/web/models.py
+++ b/codalab/apps/web/models.py
@@ -288,7 +288,7 @@ class Competition(ChaHubSaveMixin, models.Model):
     hide_chart = models.BooleanField(default=False, verbose_name="Hide Chart")
     allow_organizer_teams = models.BooleanField(default=False, verbose_name="Allow Organizer Teams")
     upper_bound_max_submission_size = models.PositiveIntegerField(
-        default=300,
+        default=settings.DEFAULT_UPPER_BOUND_MAX_SUBMISSION_SIZE_MB,
         validators=[
             MinValueValidator(0)
         ],
@@ -899,7 +899,7 @@ class CompetitionPhase(models.Model):
     color = models.CharField(max_length=24, choices=COLOR_CHOICES, blank=True, null=True)
 
     max_submission_size = models.PositiveIntegerField(
-        default=300,
+        default=settings.DEFAULT_UPPER_BOUND_MAX_SUBMISSION_SIZE_MB,
         validators=[
             MinValueValidator(0),
         ],

--- a/codalab/apps/web/static/css/admin_competitions_manager.css
+++ b/codalab/apps/web/static/css/admin_competitions_manager.css
@@ -1,0 +1,15 @@
+.admin-competitions-manager-app-container {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    height: 100%;
+    background-color: #f7f7f7;
+}
+
+.admin-competitions-manager-footer-row {
+    display: flex;
+    flex-direction: row;
+    width: 100%;
+    justify-content: flex-end;
+    margin: 24px 0px;
+}

--- a/codalab/apps/web/templates/web/admin_competitions_manager.html
+++ b/codalab/apps/web/templates/web/admin_competitions_manager.html
@@ -65,7 +65,7 @@
                                     :return-value.sync="item.upper_bound_max_submission_size"
                                     @save="save({'id': item.id, 'upper_bound_max_submission_size': item.upper_bound_max_submission_size})"
                                 >
-                                    {{ item.upper_bound_max_submission_size*1000*1000 | prettyByte }}
+                                    {{ item.upper_bound_max_submission_size * 1000 * 1000 | prettyByte }}
                                     <template v-slot:input>
                                         <v-text-field
                                             v-model="item.upper_bound_max_submission_size"
@@ -74,6 +74,19 @@
                                         ></v-text-field>
                                     </template>
                                 </v-edit-dialog>
+                            </template>
+                            <template v-slot:item.max_submission_sizes="{ item }">
+                                {{ item.max_submission_sizes.map(size => size * 1000 * 1000) | prettyByteArray | joinCustom(' | ') }}
+                            </template>
+                            <template v-slot:item.sync_button="{ item }">
+                                <v-btn 
+                                    :loading="synchronizing"
+                                    :disabled="synchronizing"
+                                    color="primary"
+                                    @click="synchronize(item)"
+                                >
+                                    Sync
+                                </v-btn>
                             </template>
                         </v-data-table>
                         <div class="admin-competitions-manager-footer-row">
@@ -126,7 +139,9 @@
                             {text: 'Organizer', value: 'creator'},
                             {text: 'Start date', value: 'start_date'},
                             {text: 'End date', value: 'end_date'},
-                            {text: 'Upper bound of the max sumbission size', value: 'upper_bound_max_submission_size'}
+                            {text: 'Upper bound of the max sumbission size', value: 'upper_bound_max_submission_size'},
+                            {text: 'Current max sumbission size per phase', value: 'max_submission_sizes'},
+                            {text: 'Apply the upper bound limit to all phases', value: 'sync_button', sortable: false}
                         ],
                         competitionsTableItems: [],
                         competitionsTableLoading: false,
@@ -134,6 +149,7 @@
                         competitionsTableSortDesc: true,
                         competitionsTableSearch: '',
                         saving: false,
+                        synchronizing: false,
                         competitionsIdToUpdate: []
                     };
                 },
@@ -223,6 +239,37 @@
                                 this.saving = false;
                             });
                         }
+                    },
+                    synchronize(competition) {
+                        console.log('synchronize', competition);
+                        this.synchronizing = true;
+                        fetch("/api/admin/competition/" + competition.id + "/apply_upper_bound_limit", {
+                            method: 'PATCH',
+                            headers: {
+                                'X-CSRFToken': csrftoken,
+                            }
+                        })
+                        .then(response => {
+                            if(response.ok) {
+                                return response.json();
+                            }
+                            throw new Error('Something went wrong');
+                        })
+                        .then(competition => {
+                            const index = this.competitionsTableItems.findIndex(comp => comp.id == competition.id);
+                            if (index >= 0) {
+                                // Using method splice for Vue reactivity (updating an element is not supported otherwise)
+                                this.competitionsTableItems.splice(index, 1, competition);
+                            } else {
+                                console.log("error: No matching competition to update");
+                            }
+                        })
+                        .catch(error => {
+                            console.log("error while fetching /api/admin/competitions", error);
+                        })
+                        .finally(() => {
+                            this.synchronizing = false;
+                        });
                     }
                 },
                 filters: {
@@ -238,6 +285,12 @@
                     },
                     prettyByte: function(bytes) {
                         return prettyBytes(bytes);
+                    },
+                    prettyByteArray: function(array) {
+                        return array.map(bytes => prettyBytes(bytes));
+                    },
+                    joinCustom: function(array, separator) {
+                        return array.join(separator);
                     }
                 }
             });

--- a/codalab/apps/web/templates/web/admin_competitions_manager.html
+++ b/codalab/apps/web/templates/web/admin_competitions_manager.html
@@ -19,6 +19,11 @@
             <v-app>
                 <v-main>
                     <div class="admin-competitions-manager-app-container">
+                        <div style="display: flex; flex-direction: row; justify-content: flex-end;">
+                            <v-btn icon href="https://github.com/codalab/codalab-competitions/wiki/Dev_Administrator-Procedures#edit-the-upper-bound-limit-of-the-max-submission-size-for-competitions">
+                                <v-icon @click="openWiki"> mdi-help-circle-outline </v-icon>
+                            </v-btn>
+                        </div>
                         <div style="display: flex; flex-direction: row; align-items: baseline">
                             <h3>Competitions</h3>
                             <v-spacer></v-spacer>
@@ -302,6 +307,9 @@
                         .finally(() => {
                             this.defaultUpperBoundLimitLoading = false;
                         });
+                    },
+                    openWiki() {
+                        console.log('ici');
                     }
                 },
                 filters: {

--- a/codalab/apps/web/templates/web/admin_competitions_manager.html
+++ b/codalab/apps/web/templates/web/admin_competitions_manager.html
@@ -4,154 +4,240 @@
 {% load codalab_tags %}
 
 {% block page_title %}Admin Competitions Manager{% endblock page_title %}
-{% block head_title %}Admin Competitions Manager{% endblock %}
+
+{% block extra_headers %}
+    <link href="https://fonts.googleapis.com/css?family=Roboto:100,300,400,500,700,900" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/@mdi/font@6.x/css/materialdesignicons.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/vuetify@2.x/dist/vuetify.min.css" rel="stylesheet">
+    <link href="{% static "css/admin_competitions_manager.css" %}" rel="stylesheet">
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, minimal-ui">
+{% endblock %}
 
 {% block content %}
-<div class="row pad-top">
-    <div class="col-md-12 competition-list">
-        <form method="post">
-            {% if formset %}
-            <table class="table table-bordered">
-                <tr>
-                    <th><input type="checkbox" id="select-all-checkbox" name="select_all" value="select_all"
-                            onclick="selectAllClicked(this)"></th>
-                    <th>ID</th>
-                    <th>Title</th>
-                    <th>Organizer</th>
-                    <th>Start date</th>
-                    <th>End date</th>
-                    <th>Upper bound of the max submission size (in MB)</th>
-                </tr>
-                {{ formset.management_form }}
-                {% for form in formset %}
-                {% csrf_token %}
-                {% for hidden in form.hidden_fields %}
-                {{ hidden }}
-                {% endfor %}
-                <tr id="tr-{{ form.id.value }}">
-                    <td>
-                        <input type="checkbox" class="competition-checkbox" name="selected_competitions"
-                            value="{{ form.id.value }}" onclick="selectOneClicked(this)">
-                    </td>
-                    <td>{{ form.id.value }}</td>
-                    <td>{{ form.title }}</td>
-                    <td>{{ form.creator }}</td>
-                    <td>{{ form.instance.start_date|date:"M d, Y" }}</td>
-                    <td>
-                        {% if form.instance.end_date %}
-                            {{ form.instance.end_date|date:"M d, Y" }}
-                        {% else %}
-                            No end date
-                        {% endif %}
-                    </td>
-                    <td>{{ form.upper_bound_max_submission_size }}</td>
-                </tr>
-                {% endfor %}
-            </table>
-            <input type="submit" value="Save" class="btn btn-primary" style="float: right;">
-            {% else %}
-            <p><em>There are no competitions.</em></p>
-            {% endif %}
-        </form>
-    </div>
-</div>
+    {% verbatim %}
+        <div id="admin-competitions-manager-app">
+            <v-app>
+                <v-main>
+                    <div class="admin-competitions-manager-app-container">
+                        <h3>Competitions</h3>
+                        <v-data-table
+                            v-model="competitionsTableSelected"
+                            item-key="id"
+                            :headers="competitionsTableHeaders"
+                            :items="competitionsTableItems"
+                            :items-per-page="10"
+                            :loading="competitionsTableLoading"
+                            :sort-by.sync="competitionsTableSortBy"
+                            :sort-desc.sync="competitionsTableSortDesc"
+                            :search="competitionsTableSearch"
+                            loading-text="Loading..."
+                            show-select
+                            class="elevation-1"
+                        >
+                            <template v-slot:top>
+                                <v-text-field
+                                    v-model="competitionsTableSearch"
+                                    label="Search"
+                                    append-icon="mdi-magnify"
+                                    single-line
+                                    hide-details
+                                    clearable
+                                    class="mx-4"
+                                >
+                                </v-text-field>
+                            </template>
+                            <template v-slot:item.start_date="{ item }">
+                                {{ item.start_date | prettyDate }}
+                            </template>
+                            <template v-slot:item.end_date="{ item }">
+                                <template v-if="item.end_date">
+                                    {{ item.end_date | prettyDate }}
+                                </template>
+                                <template v-else>
+                                    -
+                                </template>
+                            </template>
+                            <template v-slot:item.upper_bound_max_submission_size="{ item }">
+                                <v-edit-dialog
+                                    :return-value.sync="item.upper_bound_max_submission_size"
+                                    @save="save({'id': item.id, 'upper_bound_max_submission_size': item.upper_bound_max_submission_size})"
+                                >
+                                    {{ item.upper_bound_max_submission_size*1000*1000 | prettyByte }}
+                                    <template v-slot:input>
+                                        <v-text-field
+                                            v-model="item.upper_bound_max_submission_size"
+                                            label="Edit"
+                                            single-line
+                                        ></v-text-field>
+                                    </template>
+                                </v-edit-dialog>
+                            </template>
+                        </v-data-table>
+                        <div class="admin-competitions-manager-footer-row">
+                            <v-btn
+                                :loading="saving"
+                                :disabled="saving || competitionsIdToUpdate.length == 0"
+                                color="primary"
+                                @click="saveAll"
+                            >
+                                Save
+                            </v-btn>
+                        </div>
+                    </div>
+                </v-main>
+            </v-app>
+        </div>
+    {% endverbatim %}
+{% endblock %}
 
-<script type="text/javascript">
-    let selectAllCheckbox;
-    let competitionCheckboxes;
-    let competitionUpperBoundMaxSubmissionSizeInputs;
-    let selectedCompetitions = new Set();
+{% block extra_scripts %}
+    <script src="https://cdn.jsdelivr.net/npm/vue@2.x/dist/vue.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/vuetify@2.x/dist/vuetify.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/moment@2.29.3/moment.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/pretty-bytes@^1"></script>
 
-    function selectOneClicked(checkbox) {
-        // Select one competition or unselect it
-        const competitionId = parseInt(checkbox.value);
-        selectCompetition(competitionId, checkbox.checked);
-        updateSelectAllCheckbox();
-    }
+    {% csrf_token %}
+    <script>
+        $(document).ready(function () {
+            const csrftoken = document.querySelector('[name=csrfmiddlewaretoken]').value;
+            new Vue({
+                el: '#admin-competitions-manager-app',
+                vuetify: new Vuetify({
+                    theme: {
+                        themes: {
+                            light: {
+                                primary: '#4b7695',
+                                secondary: '#b0bec5',
+                                accent: '#8c9eff',
+                                error: '#b71c1c',
+                            },
+                        },
+                    },
+                }),
+                data: function () {
+                    return {
+                        competitionsTableSelected: [],
+                        competitionsTableHeaders: [
+                            {text: 'ID', value: 'id'},
+                            {text: 'Title', value: 'title'},
+                            {text: 'Organizer', value: 'creator'},
+                            {text: 'Start date', value: 'start_date'},
+                            {text: 'End date', value: 'end_date'},
+                            {text: 'Upper bound of the max sumbission size', value: 'upper_bound_max_submission_size'}
+                        ],
+                        competitionsTableItems: [],
+                        competitionsTableLoading: false,
+                        competitionsTableSortBy: 'total',
+                        competitionsTableSortDesc: true,
+                        competitionsTableSearch: '',
+                        saving: false,
+                        competitionsIdToUpdate: []
+                    };
+                },
+                mounted: function () {
+                    this.getCompetitions();
+                },
+                methods: {
+                    getCompetitions() {
+                        this.competitionsTableLoading = true;
+                        fetch("/api/admin/competitions/list")
+                        .then(response => {
+                            if(response.ok) {
+                                return response.json();
+                            }
+                            throw new Error('Something went wrong');
+                        })
+                        .then(json => {
+                            this.competitionsTableItems = json;
+                        })
+                        .catch(error => {
+                            console.log("error while fetching /api/admin/competitions", error);
+                        })
+                        .finally(() => {
+                            this.competitionsTableLoading = false;
+                        });
+                    },
+                    save(item) {
+                        // Mark the competition as competition to send through the API
+                        var newCompIdToUpdate = [item.id];
 
-    function selectAllClicked(checkbox) {
-        // Select all competitions or unselect all of them
-        for (let i = 0; i < competitionCheckboxes.length; i++) {
-            selectCompetition(parseInt(competitionCheckboxes[i].value), checkbox.checked);
-            competitionCheckboxes[i].indeterminate = false;
-            competitionCheckboxes[i].checked = checkbox.checked;
-        }
-    }
+                        // Propagate the modification to all selected rows and mark them as competitions to send through the API
+                        for (const selectedCompetition of this.competitionsTableSelected) {
+                            var competition = this.competitionsTableItems.find(competition => competition.id == selectedCompetition.id);
+                            competition.upper_bound_max_submission_size = item.upper_bound_max_submission_size;
+                            newCompIdToUpdate.push(selectedCompetition.id);
+                        }
 
-    function selectCompetition(competitionId, selected) {
-        // Update the visual aspect of the selected competition row
-        const rowId = "tr-" + competitionId;
-        const competitionRow = document.querySelector('tr[id="' + rowId + '"]');
-        if (selected) {
-            competitionRow.classList.add("selected");
-            selectedCompetitions.add(competitionId);
-        } else {
-            competitionRow.classList.remove("selected");
-            selectedCompetitions.delete(competitionId);
-        }
-    }
+                        // Add them to already existing marked competitions
+                        this.competitionsIdToUpdate = [...new Set([...this.competitionsIdToUpdate, ...newCompIdToUpdate])];
 
-    function updateSelectAllCheckbox() {
-        // Update the visual aspect of the 'select all' checkbox
-        let checkedCount = 0;
-        for (let i = 0; i < competitionCheckboxes.length; i++) {
-            if (competitionCheckboxes[i].checked) {
-                checkedCount++;
-            }
-        }
-        if (checkedCount == 0) {
-            selectAllCheckbox.checked = false;
-            selectAllCheckbox.indeterminate = false;
-        } else if (checkedCount === competitionCheckboxes.length) {
-            selectAllCheckbox.checked = true;
-            selectAllCheckbox.indeterminate = false;
-        } else {
-            selectAllCheckbox.checked = false;
-            selectAllCheckbox.indeterminate = true;
-        }
-    }
-
-    function maxSubmissionSizeChanged(checkbox) {
-        // Update all selected competition max submission size
-        for (let competionId of selectedCompetitions) {
-            const row = document.querySelector('tr[id="tr-' + competionId + '"]');
-            const upperBoundmaxSumbissionSizeInput = row.querySelector('input[id$="upper_bound_max_submission_size"]');
-            upperBoundmaxSumbissionSizeInput.value = checkbox.value;
-        }
-    }
-
-    window.addEventListener('load', function () {
-        selectAllCheckbox = document.querySelector('input[id="select-all-checkbox"]');
-        competitionCheckboxes = document.querySelectorAll('td input[type="checkbox"]');
-        competitionUpperBoundMaxSubmissionSizeInputs = document.querySelectorAll('td input[id$="upper_bound_max_submission_size"]');
-
-        // Init the array of selected competitions
-        for (let i = 0; i < competitionCheckboxes.length; i++) {
-            if (competitionCheckboxes[i].checked) {
-                selectOneClicked(competitionCheckboxes[i]);
-            }
-        }
-
-        // Add onChange event listener to inputs
-        for (let input of competitionUpperBoundMaxSubmissionSizeInputs) {
-            input.addEventListener('change', () => {
-                maxSubmissionSizeChanged(input);
+                        console.log('this.competitionsIdToUpdate', this.competitionsIdToUpdate);
+                    },
+                    saveAll() {
+                        var competitionsUpdated = [];
+                        for (const id of this.competitionsIdToUpdate) {
+                            const competition = this.competitionsTableItems.find(competition => competition.id == id);
+                            competitionsUpdated.push({
+                                id: id,
+                                upper_bound_max_submission_size: competition.upper_bound_max_submission_size
+                            });
+                        }
+                        if (competitionsUpdated.length > 0) {
+                            const competitionsJson = {
+                                competitions: competitionsUpdated
+                            }
+                            this.saving = true;
+                            fetch("/api/admin/competitions/update", {
+                                method: 'POST',
+                                headers: {
+                                    'X-CSRFToken': csrftoken,
+                                    'Content-Type': 'application/json',
+                                },
+                                body: JSON.stringify(competitionsJson)
+                            })
+                            .then(response => {
+                                if(response.ok) {
+                                    return response.json();
+                                }
+                                throw new Error('Something went wrong');
+                            })
+                            .then(json => {
+                                this.competitionsIdToUpdate = [];
+                                for (const competition of json) {
+                                    const index = this.competitionsTableItems.findIndex(comp => comp.id == competition.id);
+                                    if (index >= 0) {
+                                        // Using method splice for Vue reactivity (updating an element is not supported otherwise)
+                                        this.competitionsTableItems.splice(index, 1, competition);
+                                    } else {
+                                        console.log("error: No matching competition to update");
+                                    }
+                                }
+                            })
+                            .catch(error => {
+                                console.log("error while fetching /api/admin/competitions", error);
+                            })
+                            .finally(() => {
+                                this.saving = false;
+                            });
+                        }
+                    }
+                },
+                filters: {
+                    prettyDate: function(date) {
+                        return moment(date).calendar(null, {
+                            sameDay: '[Today at] h:mm a',
+                            nextDay: '[Tomorrow at] h:mm a',
+                            nextWeek: 'dddd [at] h:mm a',
+                            lastDay: '[Yesterday at] h:mm a',
+                            lastWeek: '[Last] dddd [at] h:mm a',
+                            sameElse: 'dddd, MMMM Do YYYY [at] h:mm a'
+                        });
+                    },
+                    prettyByte: function(bytes) {
+                        return prettyBytes(bytes);
+                    }
+                }
             });
-        }
-    });
-</script>
-
-<style>
-    tr:nth-of-type(odd) {
-        background-color: #f7f7f7;
-    }
-
-    tr:nth-of-type(even) {
-        background-color: #ffffff;
-    }
-
-    tr.selected {
-        background-color: #ddeedd;
-    }
-</style>
+        })
+    </script>
 {% endblock %}

--- a/codalab/apps/web/templates/web/admin_competitions_manager.html
+++ b/codalab/apps/web/templates/web/admin_competitions_manager.html
@@ -19,7 +19,20 @@
             <v-app>
                 <v-main>
                     <div class="admin-competitions-manager-app-container">
-                        <h3>Competitions</h3>
+                        <div style="display: flex; flex-direction: row; align-items: baseline">
+                            <h3>Competitions</h3>
+                            <v-spacer></v-spacer>
+                            <span v-if="defaultUpperBoundLimitLoading"
+                                style="color: rgba(0, 0, 0, 0.6); font-size: 12px; font-weight: bold;"
+                            >
+                                Default upper bound limit: -
+                            </span>
+                            <span v-else
+                                style="color: rgba(0, 0, 0, 0.6); font-size: 12px; font-weight: bold;"
+                            >
+                                Default upper bound limit: {{ defaultUpperBoundLimit * 1000 * 1000 | prettyByte }}
+                            </span>
+                        </div>
                         <v-data-table
                             v-model="competitionsTableSelected"
                             item-key="id"
@@ -132,6 +145,8 @@
                 }),
                 data: function () {
                     return {
+                        defaultUpperBoundLimit: 300,
+                        defaultUpperBoundLimitLoading: false,
                         competitionsTableSelected: [],
                         competitionsTableHeaders: [
                             {text: 'ID', value: 'id'},
@@ -155,6 +170,7 @@
                 },
                 mounted: function () {
                     this.getCompetitions();
+                    this.getDefaultUpperBoundLimit();
                 },
                 methods: {
                     getCompetitions() {
@@ -189,8 +205,6 @@
 
                         // Add them to already existing marked competitions
                         this.competitionsIdToUpdate = [...new Set([...this.competitionsIdToUpdate, ...newCompIdToUpdate])];
-
-                        console.log('this.competitionsIdToUpdate', this.competitionsIdToUpdate);
                     },
                     saveAll() {
                         var competitionsUpdated = [];
@@ -241,7 +255,6 @@
                         }
                     },
                     synchronize(competition) {
-                        console.log('synchronize', competition);
                         this.synchronizing = true;
                         fetch("/api/admin/competition/" + competition.id + "/apply_upper_bound_limit", {
                             method: 'PATCH',
@@ -265,10 +278,29 @@
                             }
                         })
                         .catch(error => {
-                            console.log("error while fetching /api/admin/competitions", error);
+                            console.log("error while fetching /api/admin/competition/" + competition.id + "/apply_upper_bound_limit", error);
                         })
                         .finally(() => {
                             this.synchronizing = false;
+                        });
+                    },
+                    getDefaultUpperBoundLimit() {
+                        this.defaultUpperBoundLimitLoading = true;
+                        fetch("/api/admin/competitions/default_upper_bound_limit")
+                        .then(response => {
+                            if(response.ok) {
+                                return response.json();
+                            }
+                            throw new Error('Something went wrong');
+                        })
+                        .then(json => {
+                            this.defaultUpperBoundLimit = json;
+                        })
+                        .catch(error => {
+                            console.log("error while fetching /api/admin/competitions/default_upper_bound_limit", error);
+                        })
+                        .finally(() => {
+                            this.defaultUpperBoundLimitLoading = false;
                         });
                     }
                 },

--- a/codalab/apps/web/templates/web/admin_competitions_manager.html
+++ b/codalab/apps/web/templates/web/admin_competitions_manager.html
@@ -46,6 +46,9 @@
                                 >
                                 </v-text-field>
                             </template>
+                            <template v-slot:item.title="{ item }">
+                                <a :href="`/competitions/${item.id}`"> {{ item.title }} </a>
+                            </template>
                             <template v-slot:item.start_date="{ item }">
                                 {{ item.start_date | prettyDate }}
                             </template>

--- a/codalab/apps/web/views.py
+++ b/codalab/apps/web/views.py
@@ -51,7 +51,7 @@ from django.utils.html import strip_tags
 from django.utils.safestring import mark_safe
 from django.views.generic import FormView
 from django.views.generic import View, TemplateView, DetailView, ListView, UpdateView, CreateView, DeleteView
-from extra_views import UpdateWithInlinesView, InlineFormSet, NamedFormsetsMixin, ModelFormSetView
+from extra_views import UpdateWithInlinesView, InlineFormSet, NamedFormsetsMixin
 
 from .tasks import evaluate_submission, re_run_all_submissions_in_phase, create_competition, _make_url_sassy, \
     make_modified_bundle
@@ -181,33 +181,11 @@ class UserSettingsView(LoginRequiredMixin, UpdateView):
         return self.request.user
 
 
-class AdminCompetitionsManager(ModelFormSetView):
-    """Admin page for managing the competitions"""
-    model = Competition
-    template_name = "web/admin_competitions_manager.html"
-    fields = [
-        'id',
-        'title',
-        'creator',
-        'start_date',
-        'end_date',
-        'upper_bound_max_submission_size'
-    ]
-    success_url = '/admin_competitions_manager'
-    factory_kwargs = {'extra': 0}
-
-    def get(self, *args, **kwargs):
-        redirect_url = "index.html"
-        user = self.request.user
-        if user.is_staff and user.is_active:
-            return super(AdminCompetitionsManager, self).get(*args, **kwargs)
-        else:
-            return HttpResponseRedirect(redirect_url)
-
-    def get_context_data(self, **kwargs):
-        context = super(AdminCompetitionsManager, self).get_context_data(**kwargs)
-        context["object_list"] = list(models.Competition.objects.order_by('-start_date'))
-        return context
+@login_required
+def admin_competitions_manager(request):
+    if not request.user.is_staff:
+        return HttpResponse(status=403)
+    return render(request, "web/admin_competitions_manager.html")
 
 
 ############################################################

--- a/codalab/apps/web/views.py
+++ b/codalab/apps/web/views.py
@@ -44,7 +44,7 @@ from django.db import connection
 from django.db.models import Q, Max, Min, Count, Case, When
 from django.http import Http404, HttpResponseForbidden
 from django.http import HttpResponse, HttpResponseRedirect
-from django.shortcuts import render_to_response, render, get_object_or_404
+from django.shortcuts import render_to_response, render, get_object_or_404, redirect
 from django.template import RequestContext
 from django.utils import timezone
 from django.utils.html import strip_tags
@@ -183,9 +183,10 @@ class UserSettingsView(LoginRequiredMixin, UpdateView):
 
 @login_required
 def admin_competitions_manager(request):
-    if not request.user.is_staff:
-        return HttpResponse(status=403)
-    return render(request, "web/admin_competitions_manager.html")
+    if request.user.is_staff:
+        return render(request, "web/admin_competitions_manager.html")
+    else:
+        return redirect('/')
 
 
 ############################################################

--- a/codalab/codalab/settings/base.py
+++ b/codalab/codalab/settings/base.py
@@ -654,6 +654,7 @@ class Base(Configuration):
         'group_models': True,
     }
     DISABLE_SUBMISSIONS = False
+    DEFAULT_UPPER_BOUND_MAX_SUBMISSION_SIZE_MB = 300
 
     @classmethod
     def pre_setup(cls):

--- a/codalab/codalab/urls.py
+++ b/codalab/codalab/urls.py
@@ -1,4 +1,4 @@
-from apps.web.views import MyAdminView, AdminCompetitionsManager
+from apps.web.views import MyAdminView
 from django.conf import settings
 from django.conf.urls import include, url
 from django.contrib import admin
@@ -13,7 +13,7 @@ urlpatterns = [
     url(r'^api/', include('apps.api.routers')),
     url(r'^search/', include('haystack.urls')),
     url(r'^admin_monitoring_links/$', MyAdminView.as_view(), name='admin_monitoring_links'),
-    url(r'^admin_competitions_manager/$', AdminCompetitionsManager.as_view(), name='admin_competitions_manager'),
+    url(r'^admin_competitions_manager', views.admin_competitions_manager, name='admin_competitions_manager'),
     url(r'^teams/', include('apps.teams.urls')),
     url(r'^newsletter/', include('apps.newsletter.urls', app_name='newsletter', namespace='newsletter')),
 


### PR DESCRIPTION
# Description

This PR adds useful features to the admin-competitions-manager page.

DO NOT MERGE BEFORE #3266 AS IT DEPENDS ON IT

# Content

The following features has been added:
- Move the default limit into the settings (so it can be easily configurable)
- Display the limit at the top of the admin page
- In the table add columns for
  - the effective limit
  - organizer email
  - competition link
  - button to force the effective limit to be equal to the maximum limit that the admin has set
- Fix the redirection page
- Create a help button that redirect to the appropriate wiki page

# Misc. comments

Tested locally

# Reviewers

@bbearce 

# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [ ] Code review by reviewer
- [ ] Hand tested by reviewer
- [ ] Ready to merge