### PR TITLE
creation of task

### DIFF
--- a/codalab/apps/web/tasks.py
+++ b/codalab/apps/web/tasks.py
@@ -966,6 +966,18 @@ def create_storage_analytics_snapshot():
 
 
 @task(queue='site-worker')
+def reset_computed_storage_analytics():
+    logger.info("Task reset_computed_storage_analytics started")
+    starting_time = time.process_time()
+
+    # Reset the value of all computed sizes so they will be re-computed again without any shifting on the next run of the storage analytics task
+    CompetitionSubmission.objects.all().update(sub_size=0)
+
+    elapsed_time = time.process_time() - starting_time
+    logger.info("Task reset_computed_storage_analytics stoped. Duration = {:.3f} seconds".format(elapsed_time))
+
+
+@task(queue='site-worker')
 def do_phase_migrations():
     competitions = Competition.objects.filter(is_migrating=False)
     logger.info("Checking {} competitions for phase migrations.".format(len(competitions)))

--- a/codalab/codalab/settings/base.py
+++ b/codalab/codalab/settings/base.py
@@ -496,6 +496,10 @@ class Base(Configuration):
             'task': 'apps.web.tasks.create_storage_analytics_snapshot',
             'schedule': crontab(hour=2, minute=0, day_of_week='sun') # Every Sunday at 02:00
         },
+        'reset_computed_storage_analytics': {
+            'task': 'apps.web.tasks.reset_computed_storage_analytics',
+            'schedule': crontab(minute=0, hour=2, day_of_month=1, month_of_year="*/3") # Every 3 month at 02:00 on the 1st
+        }
     }
     CELERY_TIMEZONE = 'UTC'
 


### PR DESCRIPTION
# Description
In order to avoid size measurement shift this PR introduce a new task that is reseting the measured size of files every 3 month so the storage analytics task will recompute them.

# Misc. comments
Testing locally and very fast: 2ms on Barcelona database replica
Note: Setting the column 'sub_size' to 0 for submissions will tell the storage analytics to measure its size from the bucket instead of using the a stored value: https://github.com/codalab/codalab-competitions/blob/develop/codalab/apps/web/models.py#L1454

# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [ ] Code review by reviewer
- [ ] Hand tested by reviewer
- [ ] Ready to merge
