### PR TITLE
Update upload_backup.py

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
       DJANGO_SETTINGS_MODULE: codalab.settings
       DJANGO_CONFIGURATION: Dev
     docker:
-      - image: circleci/python:3.8.3
+      - image: cimg/python:3.8
     steps:
       - checkout
       - restore_cache:

--- a/.github/workflows/run-pytest.yaml
+++ b/.github/workflows/run-pytest.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Set up Python 3.8
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8.3
+          python-version: 3.8
       - name: Cache pip
         uses: actions/cache@v2
         with:

--- a/.github/workflows/run-pytest.yaml
+++ b/.github/workflows/run-pytest.yaml
@@ -52,7 +52,7 @@ jobs:
           echo "127.0.0.1 memcached" | sudo tee --append /etc/hosts
       - name: Install dependencies
         run: |
-          sudo apt-get install libxml2-dev libxslt-dev python-dev
+          sudo apt-get install libxml2-dev libxslt-dev python-dev-is-python3
           sudo apt-get update --allow-releaseinfo-change && sudo apt-get install libmemcached-dev --fix-missing
           python -m pip install --upgrade pip
           pip install flake8 pytest pytest-cov pytest-dependency pytest-django

--- a/codalab/apps/web/management/commands/upload_backup.py
+++ b/codalab/apps/web/management/commands/upload_backup.py
@@ -10,6 +10,12 @@ from apps.web.utils import _put_blob
 class Command(BaseCommand):
     help = "Takes a database dump file and puts it on remote storage"
 
+    # needing add_arguments method after upgrading Django to 1.8
+    # see https://docs.djangoproject.com/en/1.8/releases/1.8/#extending-management-command-arguments-through-command-option-list
+    def add_arguments(self, parser):
+        parser.add_argument('args', nargs='*')
+
+
     def handle(self, *args, **options):
         if len(args) == 0:
             raise Exception("the relative dump file path is required -- it is stored in /app/backups so you do not "


### PR DESCRIPTION
Since Django 1.8, management commands now use argparse instead of optparse to parse command-line arguments passed to commands. This also means that the way to add custom arguments to commands has changed: instead of extending the option_list class list, you should now override the add_arguments() method and add arguments through argparse.add_argument(). See https://docs.djangoproject.com/en/1.8/releases/1.8/#extending-management-command-arguments-through-command-option-list

# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [X] Code review by reviewer
- [x] Hand tested by reviewer
- [x] Ready to merge
