### PR TITLE
Fix installation of deprecated anyjson package

### DIFF
--- a/.github/workflows/run-pytest.yaml
+++ b/.github/workflows/run-pytest.yaml
@@ -56,9 +56,7 @@ jobs:
           sudo apt-get update --allow-releaseinfo-change && sudo apt-get install libmemcached-dev --fix-missing          
           python -m pip install --upgrade pip
           # Patch for anyjson
-          pip install "setuptools~=57.5.0" wheel
-          python --version
-          pip freeze --all
+          pip install "setuptools~=57.5.0" wheel          
           pip install anyjson
           # End Patch for anyjson
           pip install flake8 pytest pytest-cov pytest-dependency pytest-django

--- a/.github/workflows/run-pytest.yaml
+++ b/.github/workflows/run-pytest.yaml
@@ -57,6 +57,8 @@ jobs:
           python -m pip install --upgrade pip
           # Patch for anyjson
           pip install "setuptools~=57.5.0"
+          python --version
+          pip freeze
           pip install anyjson
           # End Patch for anyjson
           pip install flake8 pytest pytest-cov pytest-dependency pytest-django

--- a/.github/workflows/run-pytest.yaml
+++ b/.github/workflows/run-pytest.yaml
@@ -58,7 +58,7 @@ jobs:
           # Patch for anyjson
           pip install "setuptools~=57.5.0"
           python --version
-          pip freeze
+          pip freeze --all
           pip install anyjson
           # End Patch for anyjson
           pip install flake8 pytest pytest-cov pytest-dependency pytest-django

--- a/.github/workflows/run-pytest.yaml
+++ b/.github/workflows/run-pytest.yaml
@@ -56,7 +56,7 @@ jobs:
           sudo apt-get update --allow-releaseinfo-change && sudo apt-get install libmemcached-dev --fix-missing          
           python -m pip install --upgrade pip
           # Patch for anyjson
-          pip install "setuptools~=57.5.0"
+          pip install "setuptools~=57.5.0" wheel
           python --version
           pip freeze --all
           pip install anyjson

--- a/.github/workflows/run-pytest.yaml
+++ b/.github/workflows/run-pytest.yaml
@@ -54,6 +54,10 @@ jobs:
         run: |
           sudo apt-get install libxml2-dev libxslt-dev python-dev-is-python3
           sudo apt-get update --allow-releaseinfo-change && sudo apt-get install libmemcached-dev --fix-missing
+          # Patch for anyjson
+          pip install "setuptools<58.0.0"
+          pip install anyjson
+          # End Patch for anyjson
           python -m pip install --upgrade pip
           pip install flake8 pytest pytest-cov pytest-dependency pytest-django
           pip install -r ./codalab/requirements/requirements.txt

--- a/.github/workflows/run-pytest.yaml
+++ b/.github/workflows/run-pytest.yaml
@@ -53,12 +53,12 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get install libxml2-dev libxslt-dev python-dev-is-python3
-          sudo apt-get update --allow-releaseinfo-change && sudo apt-get install libmemcached-dev --fix-missing
+          sudo apt-get update --allow-releaseinfo-change && sudo apt-get install libmemcached-dev --fix-missing          
+          python -m pip install --upgrade pip
           # Patch for anyjson
           pip install "setuptools~=57.5.0"
           pip install anyjson
           # End Patch for anyjson
-          python -m pip install --upgrade pip
           pip install flake8 pytest pytest-cov pytest-dependency pytest-django
           pip install -r ./codalab/requirements/requirements.txt
       - name: Lint with flake8

--- a/.github/workflows/run-pytest.yaml
+++ b/.github/workflows/run-pytest.yaml
@@ -55,7 +55,7 @@ jobs:
           sudo apt-get install libxml2-dev libxslt-dev python-dev-is-python3
           sudo apt-get update --allow-releaseinfo-change && sudo apt-get install libmemcached-dev --fix-missing
           # Patch for anyjson
-          pip install "setuptools<58.0.0"
+          pip install "setuptools~=57.5.0"
           pip install anyjson
           # End Patch for anyjson
           python -m pip install --upgrade pip


### PR DESCRIPTION
Downgrade setuptools before installing required package anyjson. This is a temporary patch to avoid errors due to the use of deprecated anyjson Python package
