### PR TITLE
Fix download csv

### DIFF
--- a/codalab/apps/web/views.py
+++ b/codalab/apps/web/views.py
@@ -935,7 +935,7 @@ class CompetitionResultsDownload(View):
     def get(self, request, *args, **kwargs):
         competition = models.Competition.objects.get(pk=self.kwargs['id'])
         any_bool = any([
-            bool(request.user.id is competition.creator.id),
+            bool(request.user.id == competition.creator.id),
             bool(request.user.id in competition.admins.all().values_list('id', flat=True)),
             bool(request.user.id in competition.participants.all().values_list('id', flat=True))]
         )

--- a/codalab/apps/web/views.py
+++ b/codalab/apps/web/views.py
@@ -934,10 +934,12 @@ class CompetitionResultsDownload(View):
 
     def get(self, request, *args, **kwargs):
         competition = models.Competition.objects.get(pk=self.kwargs['id'])
+        admin_ids = set(competition.admins.all().values_list('id', flat=True))
+        participant_ids = set(competition.participants.all().values_list('id', flat=True))
         any_bool = any([
             bool(request.user.id == competition.creator.id),
-            bool(request.user.id in competition.admins.all().values_list('id', flat=True)),
-            bool(request.user.id in competition.participants.all().values_list('id', flat=True))]
+            bool(request.user.id in admin_ids),
+            bool(request.user.id in participant_ids)]
         )
         if not any_bool:
             return HttpResponseForbidden()

--- a/codalab/apps/web/views.py
+++ b/codalab/apps/web/views.py
@@ -935,11 +935,10 @@ class CompetitionResultsDownload(View):
     def get(self, request, *args, **kwargs):
         competition = models.Competition.objects.get(pk=self.kwargs['id'])
         admin_ids = set(competition.admins.all().values_list('id', flat=True))
-        participant_ids = set(competition.participants.all().values_list('id', flat=True))
         any_bool = any([
             bool(request.user.id == competition.creator.id),
             bool(request.user.id in admin_ids),
-            bool(request.user.id in participant_ids)]
+            bool(competition.published)]
         )
         if not any_bool:
             return HttpResponseForbidden()


### PR DESCRIPTION
Fix the following issue:

- #3395 

- The condition "is creator" is fixed by replacing `is` by `==` (the keyword `is` behavior changed in Python3).
- The condtion "is participant" was replaced by "the competition is public". Indeed, when the competition is public, everybody can access the leaderboard, hence it should be possible to download it. This way, even `wget` should be able to download it.