### PR TITLE
Pin setuptools to version <58.0 to fix anyjson install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update && apt-get install -y npm netcat nodejs python-dev libmemcach
 
 RUN pip install --upgrade pip  # make things faster, hopefully
 COPY codalab/requirements/requirements.txt requirements.txt
+RUN pip install "setuptools<58.0.0"
 RUN pip install -r requirements.txt
 
 WORKDIR /app/codalab

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,9 @@ FROM --platform=linux/amd64 python:3.8.3
 RUN curl -sL https://deb.nodesource.com/setup_4.x | bash -
 RUN apt-get update && apt-get install -y npm netcat nodejs python-dev libmemcached-dev
 
-RUN pip install --upgrade pip  # make things faster, hopefully
-COPY codalab/requirements/requirements.txt requirements.txt
+RUN pip install --upgrade pip
 RUN pip install "setuptools<58.0.0"
+COPY codalab/requirements/requirements.txt requirements.txt
 RUN pip install -r requirements.txt
 
 WORKDIR /app/codalab


### PR DESCRIPTION
The goal of this change is to fix this error:

```python
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [1 lines of output]
      error in anyjson setup command: use_2to3 is invalid.
      [end of output]
```

Encountered in the CircleCI build during the install of `requirements.txt`
