### PR TITLE
upgrade rabbitmq always to the latest management version

### DIFF
--- a/docker/rabbitmq/Dockerfile
+++ b/docker/rabbitmq/Dockerfile
@@ -1,3 +1,3 @@
-FROM rabbitmq:3.6.16-management
+FROM rabbitmq:management
 
 RUN apt-get update && apt-get install -y gettext


### PR DESCRIPTION
# @ mention of reviewers
maybe @Didayolo @bbearce


# There are some vulnerabilities of RabbitMQ's old versions

https://cve.mitre.org/cgi-bin/cvekey.cgi?keyword=amqp

After this PR, the RabbitMQ will be always the latest version which helps to resolve some CVE as soon as possible.

# A checklist for hand testing
- [x] Create competition queue
- [x] Compute worker can connect to a queue and process a submission

# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [x] Code review by reviewer
- [x] Hand tested by reviewer
- [x] CircleCi tests are passing
- [x] Ready to merge
