### PR TITLE
Feature/add rabbitmq consumer timeout and fix http proxy support for django

### DIFF
--- a/.env_sample
+++ b/.env_sample
@@ -3,6 +3,13 @@
 # ----------------------------------------------------------------------------
 SUBMISSION_TEMP_DIR=/tmp/codalab
 
+# ----------------------------------------------------------------------------
+# HTTP proxy support
+# ----------------------------------------------------------------------------
+#HTTP_PROXY=http://proxy-host:port
+#HTTPS_PROXY=http://proxy-host:port
+#NO_PROXY=127.0.0.0/8,10.0.0.0/8,172.0.0.0/8
+
 
 # ----------------------------------------------------------------------------
 # Storage
@@ -94,6 +101,7 @@ RABBITMQ_DEFAULT_PASS=guest
 RABBITMQ_HOST=rabbit
 RABBITMQ_PORT=5672
 RABBITMQ_MANAGEMENT_PORT=15672
+#WORKER_CONNECTION_TIMEOUT=100000000 # milisecond
 FLOWER_BASIC_AUTH=root:password
 FLOWER_PORT=5555
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3'
 services:
   # --------------------------------------------------------------------------
   # HTTP Server
@@ -58,6 +58,7 @@ services:
     environment:
       - RABBITMQ_LOGS=/var/log/rabbitmq/output.log
       - RABBITMQ_SASL_LOGS=/var/log/rabbitmq/output_sasl.log
+      - WORKER_CONNECTION_TIMEOUT="${WORKER_CONNECTION_TIMEOUT:-100000000}"
     env_file: .env
     volumes:
       - ./docker:/app/docker

--- a/docker/rabbitmq/rabbitmq.config
+++ b/docker/rabbitmq/rabbitmq.config
@@ -1,5 +1,6 @@
 [
   {rabbit, [
+     {consumer_timeout, ${WORKER_CONNECTION_TIMEOUT}},
      {tcp_listeners, [{"::", ${RABBITMQ_PORT}}]},
      {loopback_users, []}
   ]},

--- a/docker/run_django.sh
+++ b/docker/run_django.sh
@@ -29,6 +29,11 @@ python scripts/initialize_from_fixture.py
 
 python manage.py loaddata initial_data.json initialize_site.json initial_team_data.json
 
+# Django needs to remove http proxy variables for working
+unset HTTP_PROXY
+unset HTTPS_PROXY
+unset NO_PROXY
+
 # start development server on public ip interface, on port 8000
 PYTHONUNBUFFERED=TRUE gunicorn codalab.wsgi \
     --bind django:$DJANGO_PORT \


### PR DESCRIPTION
# @Didayolo or @bbearce or @ihsan 

# Add consumer_timeout into rabbitmq config in order to overwrite default value. Add http proxy support for codalab

# A checklist for hand testing
- [x] recreate Codalab with no WORKER_CONNECTION_TIMEOUT value in .env (without variables of HTTP_PROXY, HTTPS_PROXY, NO_PROXY)
- [x] recreate Codalab with a WORKER_CONNECTION_TIMEOUT value in .env (without variables of HTTP_PROXY, HTTPS_PROXY, NO_PROXY)
- [x] recreate Codalab with HTTP_PROXY, HTTPS_PROXY and NO_PROXY variables (already done on production)


# Checklist
- [x] Code review by me 
- [x] Hand tested by me 
- [x] I'm proud of my work
- [ ] Code review by reviewer
- [ ] Hand tested by reviewer
- [ ] CircleCi tests are passing
- [ ] Ready to merge
