### PR TITLE
Update Dockerfile - python3.8-bookworm instead of python3.8.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM --platform=linux/amd64 python:3.8.3
+FROM --platform=linux/amd64 python:3.8-bookworm
 
 # For nodejs
 RUN curl -sL https://deb.nodesource.com/setup_4.x | bash -
-RUN apt-get update && apt-get install -y npm netcat nodejs python-dev libmemcached-dev
+RUN apt-get update && apt-get install -y npm netcat nodejs python3-dev libmemcached-dev
 
 RUN pip install --upgrade pip  # make things faster, hopefully
 COPY codalab/requirements/requirements.txt requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ FROM --platform=linux/amd64 python:3.8-bookworm
 RUN curl -sL https://deb.nodesource.com/setup_4.x | bash -
 RUN apt-get update && apt-get install -y npm netcat nodejs python3-dev libmemcached-dev
 
-RUN pip install --upgrade "pip<24.1" # make things faster, hopefully
+# Force pip 23.3.1, compatible with celery 4.4.6
+RUN python -m pip install --no-cache-dir "pip==23.3.1"
 COPY codalab/requirements/requirements.txt requirements.txt
 RUN pip install -r requirements.txt
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM --platform=linux/amd64 python:3.8-bookworm
 RUN curl -sL https://deb.nodesource.com/setup_4.x | bash -
 RUN apt-get update && apt-get install -y npm netcat nodejs python3-dev libmemcached-dev
 
-RUN pip install --upgrade pip  # make things faster, hopefully
+RUN pip install --upgrade "pip<24.1" # make things faster, hopefully
 COPY codalab/requirements/requirements.txt requirements.txt
 RUN pip install -r requirements.txt
 

--- a/codalab/requirements/requirements.txt
+++ b/codalab/requirements/requirements.txt
@@ -42,7 +42,7 @@ django-bootstrap-form==3.4
 newrelic==2.54.0.41
 pylibmc==1.5.2
 
-celery==4.4.6
+celery==4.4.7
 boto3==1.14.22
 # We need a modified s3direct 0.4.1 which can use AWS_S3_HOST instead of forcing aws
 git+https://github.com/codalab/django-s3direct.git@feature/allow-different-endpoint

--- a/codalab/requirements/requirements.txt
+++ b/codalab/requirements/requirements.txt
@@ -42,7 +42,7 @@ django-bootstrap-form==3.4
 newrelic==2.54.0.41
 pylibmc==1.5.2
 
-celery==4.4.7
+celery==4.4.6
 boto3==1.14.22
 # We need a modified s3direct 0.4.1 which can use AWS_S3_HOST instead of forcing aws
 git+https://github.com/codalab/django-s3direct.git@feature/allow-different-endpoint


### PR DESCRIPTION
# Description

Change the base docker image to use Debian 12 instead of Debian 10 and hopefully fix the TLS certificate problem.

# Checklist
- [ ] Code review by me 
- [ ] Hand tested by me 
- [ ] I'm proud of my work
- [ ] Code review by reviewer
- [ ] Hand tested by reviewer
- [ ] CircleCi tests are passing
- [ ] Ready to merge
